### PR TITLE
Add shared currency formatter & badge

### DIFF
--- a/ice-order-ui/src/components/PaymentMethodBadge.jsx
+++ b/ice-order-ui/src/components/PaymentMethodBadge.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export default function PaymentMethodBadge({ isPettyCash, paymentMethod }) {
+    if (isPettyCash) {
+        return (
+            <div className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800 border border-green-200">
+                <div className="w-2 h-2 bg-green-500 rounded-full mr-2"></div>
+                เงินสดย่อย
+            </div>
+        );
+    }
+
+    return (
+        <div className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800 border border-blue-200">
+            <div className="w-2 h-2 bg-blue-500 rounded-full mr-2"></div>
+            {paymentMethod || 'โอนธนาคาร'}
+        </div>
+    );
+}

--- a/ice-order-ui/src/expenses/ExpenseDashboard.jsx
+++ b/ice-order-ui/src/expenses/ExpenseDashboard.jsx
@@ -3,12 +3,9 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { apiService } from '../apiService'; // Adjust path if needed
 import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer, LineChart, Line, XAxis, YAxis, CartesianGrid } from 'recharts';
 import { TrendingUpIcon, TrendingDownIcon, CategoryIcon, CashTodayIcon, CustomWalletIcon } from '../components/Icons';
+import { formatCurrency } from '../utils/currency';
+import PaymentMethodBadge from '../components/PaymentMethodBadge';
 
-// --- Helper to format currency ---
-const formatCurrency = (amount, currency = 'THB') => {
-    if (amount === null || amount === undefined || isNaN(parseFloat(amount))) return 'N/A';
-    return new Intl.NumberFormat('th-TH', { style: 'currency', currency: currency, minimumFractionDigits: 2 }).format(amount);
-};
 
 // --- Helper for Pie Chart ---
 const processPieChartData = (data, topN = 6) => {
@@ -51,23 +48,6 @@ const StatusIndicator = ({ status, size = 'sm' }) => {
     );
 };
 
-const PaymentMethodBadge = ({ isPettyCash, amount }) => {
-    if (isPettyCash) {
-        return (
-            <div className="flex items-center text-xs">
-                <span className="w-3 h-3 bg-green-500 rounded-full mr-2"></span>
-                <span className="text-green-700 font-medium">เงินสดย่อย</span>
-            </div>
-        );
-    } else {
-        return (
-            <div className="flex items-center text-xs">
-                <span className="w-3 h-3 bg-blue-500 rounded-full mr-2"></span>
-                <span className="text-blue-700 font-medium">โอนธนาคาร</span>
-            </div>
-        );
-    }
-};
 
 // --- Enhanced Summary Card Component ---
 const EnhancedSummaryCard = ({ title, value, icon, trendValue, trendDirection, subtitle, details = [], status }) => {

--- a/ice-order-ui/src/expenses/ExpenseList.jsx
+++ b/ice-order-ui/src/expenses/ExpenseList.jsx
@@ -1,11 +1,7 @@
 // Enhanced ExpenseList.jsx - Building on your existing structure
 import React from 'react';
-
-// Enhanced formatting functions
-const formatCurrency = (amount) => {
-    if (amount === null || amount === undefined || isNaN(parseFloat(amount))) return '฿0.00';
-    return new Intl.NumberFormat('th-TH', { style: 'currency', currency: 'THB', minimumFractionDigits: 2 }).format(amount);
-};
+import { formatCurrency } from '../utils/currency';
+import PaymentMethodBadge from '../components/PaymentMethodBadge';
 
 const formatDate = (dateString) => {
     if (!dateString) return 'ไม่มีข้อมูล';
@@ -16,25 +12,6 @@ const formatDate = (dateString) => {
     });
 };
 
-// Payment Method Badge Component
-const PaymentMethodBadge = ({ paymentMethod, isPettyCash }) => {
-    if (isPettyCash) {
-        return (
-            <div className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800 border border-green-200">
-                <div className="w-2 h-2 bg-green-500 rounded-full mr-2"></div>
-                เงินสดย่อย
-            </div>
-        );
-    } else {
-        // Bank transfer or other methods
-        return (
-            <div className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800 border border-blue-200">
-                <div className="w-2 h-2 bg-blue-500 rounded-full mr-2"></div>
-                {paymentMethod || 'โอนธนาคาร'}
-            </div>
-        );
-    }
-};
 
 // Amount Display Component with visual emphasis
 const AmountDisplay = ({ amount, isPettyCash }) => {

--- a/ice-order-ui/src/expenses/ExpenseReports.jsx
+++ b/ice-order-ui/src/expenses/ExpenseReports.jsx
@@ -1,6 +1,7 @@
 // Suggested path: src/expenses/ExpenseReports.jsx
 import React, { useState, useEffect, useCallback } from 'react';
 import { apiService } from '../apiService'; // Adjust path if needed
+import { formatCurrency } from '../utils/currency';
 
 // Helper to format date
 const formatDate = (dateString) => {
@@ -9,11 +10,6 @@ const formatDate = (dateString) => {
     return date.toLocaleDateString('en-CA'); // YYYY-MM-DD, or choose preferred locale
 };
 
-// Helper to format currency (Thai Baht)
-const formatCurrency = (amount) => {
-    if (amount === null || amount === undefined || isNaN(parseFloat(amount))) return 'N/A';
-    return new Intl.NumberFormat('th-TH', { style: 'currency', currency: 'THB', minimumFractionDigits: 2 }).format(amount);
-};
 
 // --- Icon for Download (Placeholder) ---
 const DownloadIcon = () => (

--- a/ice-order-ui/src/expenses/PettyCashLogList.jsx
+++ b/ice-order-ui/src/expenses/PettyCashLogList.jsx
@@ -1,5 +1,6 @@
 // Suggested path: src/expenses/PettyCashLogList.jsx
 import React from 'react';
+import { formatCurrency } from '../utils/currency';
 
 // --- Icon Components (can be moved to a shared icons file) ---
 const EditIcon = () => (
@@ -37,11 +38,6 @@ const formatDate = (dateString) => {
     return date.toLocaleDateString('en-CA'); // YYYY-MM-DD, or choose preferred locale
 };
 
-// Helper to format currency (Thai Baht)
-const formatCurrency = (amount) => {
-    if (amount === null || amount === undefined || isNaN(parseFloat(amount))) return '0.00'; // Default to 0.00 if N/A
-    return new Intl.NumberFormat('th-TH', { style: 'currency', currency: 'THB', minimumFractionDigits: 2 }).format(amount);
-};
 
 const PettyCashLogList = ({
     logs,

--- a/ice-order-ui/src/expenses/PettyCashLogManager.jsx
+++ b/ice-order-ui/src/expenses/PettyCashLogManager.jsx
@@ -5,6 +5,7 @@ import PettyCashLogList from './PettyCashLogList'; // Import the actual componen
 import PettyCashLogForm from './PettyCashLogForm'; // Import the actual component
 // Modal is used by PettyCashLogForm, no direct import needed here.
 import { formatDateForInput } from '../utils/dateUtils';
+import { formatCurrency } from '../utils/currency';
 
 // Simple Plus Icon
 const PlusIcon = () => (
@@ -151,13 +152,6 @@ export default function PettyCashLogManager() {
             setTimeout(() => setSuccessMessage(''), 5000);
         }
     };
-
-    // Helper to format currency for display (can be moved to a utils file)
-    const formatCurrency = (amount) => {
-        if (amount === null || amount === undefined || isNaN(parseFloat(amount))) return '0.00';
-        return new Intl.NumberFormat('th-TH', { style: 'currency', currency: 'THB', minimumFractionDigits: 2 }).format(amount);
-    };
-
 
     // Basic filter UI
     const FilterSection = () => (

--- a/ice-order-ui/src/utils/currency.js
+++ b/ice-order-ui/src/utils/currency.js
@@ -1,0 +1,10 @@
+export const formatCurrency = (amount) => {
+    if (amount === null || amount === undefined || isNaN(parseFloat(amount))) {
+        return '฿0.00';
+    }
+    return new Intl.NumberFormat('th-TH', {
+        style: 'currency',
+        currency: 'THB',
+        minimumFractionDigits: 2
+    }).format(amount);
+};


### PR DESCRIPTION
## Summary
- add `formatCurrency` helper
- create reusable `PaymentMethodBadge` component
- use `formatCurrency` across expense components
- replace inline badge code with shared component

## Testing
- `npm test` *(fails: app is not defined in inventoryDashboard.test.js)*
- `cd ice-order-ui && npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bfbe9c5f083289a81b85092ba7f0d