### PR TITLE
Add route test suites

### DIFF
--- a/tests/driversRoutes.test.js
+++ b/tests/driversRoutes.test.js
@@ -1,0 +1,140 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../db/postgres', () => ({
+  query: jest.fn(),
+  getClient: jest.fn()
+}));
+
+jest.mock('../middleware/auth', () => ({
+  authMiddleware: (req, res, next) => { req.user = { id: 1 }; next(); },
+  requireRole: () => (req, res, next) => next()
+}));
+
+const driverRoutes = require('../routes/drivers');
+const db = require('../db/postgres');
+
+describe('driver routes', () => {
+  let app;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api/drivers', driverRoutes);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('POST /api/drivers creates driver', async () => {
+    const row = {
+      driver_id: 1,
+      first_name: 'John',
+      last_name: null,
+      phone_number: '123',
+      license_plate: null,
+      is_active: true,
+      notes: null,
+      created_at: '2024-01-01',
+      updated_at: '2024-01-01',
+      created_by_user_id: 1,
+      last_updated_by_user_id: 1
+    };
+    db.query.mockResolvedValueOnce({ rows: [row] });
+
+    const res = await request(app)
+      .post('/api/drivers')
+      .send({ name: 'John', phone_number: '123' });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.body).toEqual({ ...row, name: row.first_name });
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO drivers'),
+      ['John', '123', null, true, null, 1]
+    );
+  });
+
+  test('GET /api/drivers returns list', async () => {
+    const row = {
+      driver_id: 1,
+      first_name: 'John',
+      last_name: null,
+      phone_number: '123',
+      license_plate: null,
+      is_active: true,
+      notes: null,
+      created_at: '2024-01-01',
+      updated_at: '2024-01-01',
+      created_by_user_id: 1,
+      last_updated_by_user_id: 1
+    };
+    db.query.mockResolvedValueOnce({ rows: [row] });
+
+    const res = await request(app).get('/api/drivers');
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual([{ ...row, name: row.first_name }]);
+  });
+
+  test('GET /api/drivers/:id returns driver', async () => {
+    const row = {
+      driver_id: 1,
+      first_name: 'John',
+      last_name: null,
+      phone_number: '123',
+      license_plate: null,
+      is_active: true,
+      notes: null,
+      created_at: '2024-01-01',
+      updated_at: '2024-01-01',
+      created_by_user_id: 1,
+      last_updated_by_user_id: 1
+    };
+    db.query.mockResolvedValueOnce({ rows: [row] });
+
+    const res = await request(app).get('/api/drivers/1');
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ ...row, name: row.first_name });
+  });
+
+  test('PUT /api/drivers/:id updates driver', async () => {
+    const row = {
+      driver_id: 1,
+      first_name: 'Jane',
+      last_name: null,
+      phone_number: '123',
+      license_plate: null,
+      is_active: true,
+      notes: null,
+      created_at: '2024-01-01',
+      updated_at: '2024-01-02',
+      created_by_user_id: 1,
+      last_updated_by_user_id: 1
+    };
+    db.query.mockResolvedValueOnce({ rows: [row] });
+
+    const res = await request(app)
+      .put('/api/drivers/1')
+      .send({ name: 'Jane' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ ...row, name: row.first_name });
+    expect(db.query).toHaveBeenCalledWith(expect.stringContaining('UPDATE drivers'), expect.any(Array));
+  });
+
+  test('DELETE /api/drivers/:id deactivates driver', async () => {
+    const row = { driver_id: 1, first_name: 'John', last_name: null, is_active: false };
+    db.query.mockResolvedValueOnce({ rows: [row] });
+
+    const res = await request(app).delete('/api/drivers/1');
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      message: 'Driver deactivated successfully.',
+      driver: { ...row, name: row.first_name }
+    });
+    expect(db.query).toHaveBeenCalledWith(expect.stringContaining('UPDATE drivers'), [1, 1]);
+  });
+});

--- a/tests/tiresRoutes.test.js
+++ b/tests/tiresRoutes.test.js
@@ -1,0 +1,92 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../controllers/tireController', () => {
+  const controller = {};
+  return new Proxy(controller, {
+    get: (target, prop) => {
+      if (!target[prop]) target[prop] = jest.fn((req, res) => res.status(200).end());
+      return target[prop];
+    }
+  });
+});
+
+jest.mock('../middleware/auth', () => {
+  let role = 'admin';
+  return {
+    __setRole: r => { role = r; },
+    authMiddleware: (req, res, next) => { req.user = { id: 1, role }; next(); },
+    requireRole: roles => (req, res, next) => {
+      if (!roles.includes(role)) return res.status(403).json({ message: 'Forbidden' });
+      next();
+    }
+  };
+});
+
+const tireRoutes = require('../routes/tires');
+const tireController = require('../controllers/tireController');
+const { __setRole } = require('../middleware/auth');
+
+describe('tire routes', () => {
+  let app;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api/tires', tireRoutes);
+    jest.clearAllMocks();
+  });
+
+  test('GET /api/tires returns list', async () => {
+    tireController.getAllTires.mockImplementation((req, res) => res.status(200).json([]));
+    const res = await request(app).get('/api/tires');
+    expect(res.statusCode).toBe(200);
+    expect(tireController.getAllTires).toHaveBeenCalled();
+  });
+
+  test('POST /api/tires allowed roles', async () => {
+    __setRole('manager');
+    tireController.addTire.mockImplementation((req, res) => res.status(201).json({ id: 1 }));
+    const res = await request(app).post('/api/tires');
+    expect(res.statusCode).toBe(201);
+    expect(tireController.addTire).toHaveBeenCalled();
+  });
+
+  test('POST /api/tires forbidden for wrong role', async () => {
+    __setRole('driver');
+    const res = await request(app).post('/api/tires');
+    expect(res.statusCode).toBe(403);
+    expect(tireController.addTire).not.toHaveBeenCalled();
+  });
+
+  test('GET /api/tires/assignments uses controller', async () => {
+    tireController.getAllAssignments.mockImplementation((req, res) => res.status(200).json([]));
+    const res = await request(app).get('/api/tires/assignments');
+    expect(res.statusCode).toBe(200);
+    expect(tireController.getAllAssignments).toHaveBeenCalled();
+  });
+
+  test('PUT /api/tires/:id updates tire', async () => {
+    __setRole('staff');
+    tireController.updateTire.mockImplementation((req, res) => res.status(200).json({ ok: true }));
+    const res = await request(app).put('/api/tires/1');
+    expect(res.statusCode).toBe(200);
+    expect(tireController.updateTire).toHaveBeenCalled();
+  });
+
+  test('POST /api/tires/assign calls controller', async () => {
+    __setRole('admin');
+    tireController.assignTire.mockImplementation((req, res) => res.status(201).json({ status: 'On Vehicle' }));
+    const res = await request(app).post('/api/tires/assign');
+    expect(res.statusCode).toBe(201);
+    expect(tireController.assignTire).toHaveBeenCalled();
+  });
+
+  test('PUT /api/tires/unmount/:id calls controller', async () => {
+    __setRole('manager');
+    tireController.unmountTire.mockImplementation((req, res) => res.status(200).json({ status: 'In Stock' }));
+    const res = await request(app).put('/api/tires/unmount/1');
+    expect(res.statusCode).toBe(200);
+    expect(tireController.unmountTire).toHaveBeenCalled();
+  });
+});

--- a/tests/vehiclesRoutes.test.js
+++ b/tests/vehiclesRoutes.test.js
@@ -1,0 +1,115 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../controllers/vehicleController', () => {
+  const controller = {};
+  return new Proxy(controller, {
+    get: (target, prop) => {
+      if (!target[prop]) target[prop] = jest.fn((req, res) => res.status(200).end());
+      return target[prop];
+    }
+  });
+});
+
+jest.mock('../middleware/auth', () => {
+  let role = 'admin';
+  return {
+    __setRole: r => { role = r; },
+    authMiddleware: (req, res, next) => { req.user = { id: 1, role }; next(); },
+    requireRole: roles => (req, res, next) => {
+      if (!roles.includes(role)) return res.status(403).json({ message: 'Forbidden' });
+      next();
+    }
+  };
+});
+
+const vehicleRoutes = require('../routes/vehicles');
+const vehicleController = require('../controllers/vehicleController');
+const { __setRole } = require('../middleware/auth');
+
+describe('vehicle routes', () => {
+  let app;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api/vehicles', vehicleRoutes);
+    jest.clearAllMocks();
+  });
+
+  test('GET /api/vehicles uses controller', async () => {
+    vehicleController.getAllVehicles.mockImplementation((req, res) => res.status(200).json([{ id: 1 }]));
+    const res = await request(app).get('/api/vehicles');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual([{ id: 1 }]);
+    expect(vehicleController.getAllVehicles).toHaveBeenCalled();
+  });
+
+  test('POST /api/vehicles calls addVehicle with role allowed', async () => {
+    __setRole('admin');
+    vehicleController.addVehicle.mockImplementation((req, res) => res.status(201).json({ id: 2 }));
+    const res = await request(app).post('/api/vehicles');
+    expect(res.statusCode).toBe(201);
+    expect(res.body).toEqual({ id: 2 });
+    expect(vehicleController.addVehicle).toHaveBeenCalled();
+  });
+
+  test('POST /api/vehicles forbidden for unauthorized role', async () => {
+    __setRole('driver');
+    const res = await request(app).post('/api/vehicles');
+    expect(res.statusCode).toBe(403);
+    expect(vehicleController.addVehicle).not.toHaveBeenCalled();
+  });
+
+  test('GET /api/vehicles/:id uses controller', async () => {
+    vehicleController.getVehicleById.mockImplementation((req, res) => res.status(200).json({ id: req.params.id }));
+    const res = await request(app).get('/api/vehicles/5');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ id: '5' });
+    expect(vehicleController.getVehicleById).toHaveBeenCalled();
+  });
+
+  test('PUT /api/vehicles/:id requires role', async () => {
+    __setRole('staff');
+    vehicleController.updateVehicle.mockImplementation((req, res) => res.status(200).json({ ok: true }));
+    const res = await request(app).put('/api/vehicles/1');
+    expect(res.statusCode).toBe(200);
+    expect(vehicleController.updateVehicle).toHaveBeenCalled();
+  });
+
+  test('PUT /api/vehicles/:id forbidden for wrong role', async () => {
+    __setRole('guest');
+    const res = await request(app).put('/api/vehicles/1');
+    expect(res.statusCode).toBe(403);
+    expect(vehicleController.updateVehicle).not.toHaveBeenCalled();
+  });
+
+  test('DELETE /api/vehicles/:id allowed roles', async () => {
+    __setRole('admin');
+    vehicleController.deleteVehicle.mockImplementation((req, res) => res.status(200).json({ removed: true }));
+    const res = await request(app).delete('/api/vehicles/1');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ removed: true });
+    expect(vehicleController.deleteVehicle).toHaveBeenCalled();
+  });
+
+  test('DELETE /api/vehicles/:id forbidden role', async () => {
+    __setRole('staff');
+    const res = await request(app).delete('/api/vehicles/1');
+    expect(res.statusCode).toBe(403);
+    expect(vehicleController.deleteVehicle).not.toHaveBeenCalled();
+  });
+
+  test('maintenance routes call controller', async () => {
+    vehicleController.getMaintenanceForVehicle.mockImplementation((req, res) => res.status(200).json([]));
+    const res1 = await request(app).get('/api/vehicles/1/maintenance');
+    expect(res1.statusCode).toBe(200);
+    expect(vehicleController.getMaintenanceForVehicle).toHaveBeenCalled();
+
+    __setRole('manager');
+    vehicleController.addMaintenance.mockImplementation((req, res) => res.status(201).json({ id: 1 }));
+    const res2 = await request(app).post('/api/vehicles/1/maintenance');
+    expect(res2.statusCode).toBe(201);
+    expect(vehicleController.addMaintenance).toHaveBeenCalled();
+  });
+});

--- a/tests/waterRoutes.test.js
+++ b/tests/waterRoutes.test.js
@@ -1,0 +1,59 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../controllers/waterController', () => {
+  const controller = {};
+  return new Proxy(controller, {
+    get: (target, prop) => {
+      if (!target[prop]) target[prop] = jest.fn((req, res) => res.status(200).end());
+      return target[prop];
+    }
+  });
+});
+
+jest.mock('../middleware/auth', () => ({
+  authMiddleware: (req, res, next) => { req.user = { id: 1 }; next(); },
+  requireRole: () => (req, res, next) => next()
+}));
+
+const waterRoutes = require('../routes/water');
+const waterController = require('../controllers/waterController');
+
+describe('water routes', () => {
+  let app;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api/water', waterRoutes);
+    jest.clearAllMocks();
+  });
+
+  test('GET /logs returns logs', async () => {
+    waterController.getAllWaterLogs.mockImplementation((req, res) => res.status(200).json([]));
+    const res = await request(app).get('/api/water/logs');
+    expect(res.statusCode).toBe(200);
+    expect(waterController.getAllWaterLogs).toHaveBeenCalled();
+  });
+
+  test('POST /logs adds log', async () => {
+    waterController.addWaterLog.mockImplementation((req, res) => res.status(201).json({ id: 1 }));
+    const res = await request(app).post('/api/water/logs');
+    expect(res.statusCode).toBe(201);
+    expect(waterController.addWaterLog).toHaveBeenCalled();
+  });
+
+  test('GET /logs/recent calls controller', async () => {
+    waterController.getRecentWaterLogs.mockImplementation((req, res) => res.status(200).json([]));
+    const res = await request(app).get('/api/water/logs/recent');
+    expect(res.statusCode).toBe(200);
+    expect(waterController.getRecentWaterLogs).toHaveBeenCalled();
+  });
+
+  test('GET /stages calls controller', async () => {
+    waterController.getTestStages.mockImplementation((req, res) => res.status(200).json([]));
+    const res = await request(app).get('/api/water/stages');
+    expect(res.statusCode).toBe(200);
+    expect(waterController.getTestStages).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for drivers routes using mocked DB
- create controller-driven tests for vehicle, tire and water routes
- ensure CRUD and status transitions return expected codes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e99a5e56c8328ac0207e54c41bbb9