### PR TITLE
Add tests for logs filtering and bill rendering

### DIFF
--- a/tests/logsRoutes.test.js
+++ b/tests/logsRoutes.test.js
@@ -1,0 +1,66 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../db/postgres', () => ({
+  query: jest.fn(),
+  getClient: jest.fn(),
+}));
+
+jest.mock('../middleware/auth', () => ({
+  authMiddleware: (req, res, next) => { req.user = { id: 1 }; next(); },
+  requireRole: () => (req, res, next) => next(),
+}));
+
+const logsRoutes = require('../routes/logs');
+const db = require('../db/postgres');
+
+describe('logs routes', () => {
+  let app;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api/logs', logsRoutes);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('GET /api/logs filters by all parameters', async () => {
+    db.query.mockResolvedValueOnce({ rows: [{ id: 1 }] });
+
+    const res = await request(app).get('/api/logs?userId=1&orderId=2&action=create');
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual([{ id: 1 }]);
+
+    const [sql, params] = db.query.mock.calls[0];
+    expect(sql).toEqual(expect.stringContaining('userid = $1'));
+    expect(sql).toEqual(expect.stringContaining('orderid = $2'));
+    expect(sql).toEqual(expect.stringContaining('action = $3'));
+    expect(params).toEqual([1, 2, 'create']);
+  });
+
+  test('GET /api/logs filters by userId only', async () => {
+    db.query.mockResolvedValueOnce({ rows: [] });
+
+    await request(app).get('/api/logs?userId=5');
+
+    const [sql, params] = db.query.mock.calls[0];
+    expect(sql).toEqual(expect.stringContaining('userid = $1'));
+    expect(sql).not.toEqual(expect.stringContaining('orderid = $2'));
+    expect(params).toEqual([5]);
+  });
+
+  test('GET /api/logs filters by userId and action', async () => {
+    db.query.mockResolvedValueOnce({ rows: [] });
+
+    await request(app).get('/api/logs?userId=3&action=update');
+
+    const [sql, params] = db.query.mock.calls[0];
+    expect(sql).toEqual(expect.stringContaining('userid = $1'));
+    expect(sql).toEqual(expect.stringContaining('action = $2'));
+    expect(params).toEqual([3, 'update']);
+  });
+});

--- a/tests/printBill.test.js
+++ b/tests/printBill.test.js
@@ -1,0 +1,49 @@
+const request = require('supertest');
+const express = require('express');
+const path = require('path');
+
+jest.mock('../db/postgres', () => ({
+  query: jest.fn(),
+  getClient: jest.fn(),
+}));
+
+const printBillRoute = require('../routes/printBill');
+const db = require('../db/postgres');
+
+describe('print bill route', () => {
+  let app;
+  let renderMock;
+
+  beforeEach(() => {
+    app = express();
+    app.set('views', path.join(__dirname, '..', 'views'));
+    app.set('view engine', 'ejs');
+    renderMock = jest.spyOn(app.response, 'render').mockImplementation(function(view, options) {
+      this.send('rendered');
+    });
+    app.use('/print-bill', printBillRoute);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
+
+  test('GET /print-bill/:id renders bill-preview with data', async () => {
+    const orderRow = { id: 1, customerName: 'John' };
+    const itemRow = { id: 2, orderId: 1 };
+    db.query
+      .mockResolvedValueOnce({ rows: [orderRow] })
+      .mockResolvedValueOnce({ rows: [itemRow] });
+
+    const res = await request(app).get('/print-bill/1');
+
+    expect(res.statusCode).toBe(200);
+    expect(renderMock).toHaveBeenCalledWith('bill-preview', expect.objectContaining({
+      order: orderRow,
+      orderItems: [itemRow],
+      formatDate: expect.any(Function),
+      toBahtText: expect.any(Function),
+    }));
+  });
+});


### PR DESCRIPTION
## Summary
- test query filtering in `routes/logs.js`
- add unit test for bill rendering in `routes/printBill.js`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687e99a5686c83289f59e166419ce0fc