### PR TITLE
Add component tests

### DIFF
--- a/ice-order-ui/.babelrc
+++ b/ice-order-ui/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-react"]
+  "presets": ["@babel/preset-env", "@babel/preset-react"],
+  "plugins": ["babel-plugin-transform-vite-meta-env"]
 }

--- a/ice-order-ui/package-lock.json
+++ b/ice-order-ui/package-lock.json
@@ -35,6 +35,8 @@
         "@vitejs/plugin-react": "^4.3.4",
         "autoprefixer": "^10.4.21",
         "babel-jest": "^29.7.0",
+        "babel-plugin-transform-import-meta": "^2.3.3",
+        "babel-plugin-transform-vite-meta-env": "^1.0.3",
         "eslint": "^9.22.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.19",
@@ -4495,6 +4497,31 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-transform-import-meta": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-import-meta/-/babel-plugin-transform-import-meta-2.3.3.tgz",
+      "integrity": "sha512-bbh30qz1m6ZU1ybJoNOhA2zaDvmeXMnGNBMVMDOJ1Fni4+wMBoy/j7MTRVmqAUCIcy54/rEnr9VEBsfcgbpm3Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/template": "^7.25.9",
+        "tslib": "^2.8.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.10.0"
+      }
+    },
+    "node_modules/babel-plugin-transform-vite-meta-env": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-vite-meta-env/-/babel-plugin-transform-vite-meta-env-1.0.3.tgz",
+      "integrity": "sha512-eyfuDEXrMu667TQpmctHeTlJrZA6jXYHyEJFjcM0yEa60LS/LXlOg2PBbMb8DVS+V9CnTj/j9itdlDVMcY2zEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.9",
+        "@types/babel__core": "^7.1.12"
       }
     },
     "node_modules/babel-preset-current-node-syntax": {

--- a/ice-order-ui/package.json
+++ b/ice-order-ui/package.json
@@ -38,6 +38,8 @@
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.21",
     "babel-jest": "^29.7.0",
+    "babel-plugin-transform-import-meta": "^2.3.3",
+    "babel-plugin-transform-vite-meta-env": "^1.0.3",
     "eslint": "^9.22.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",

--- a/ice-order-ui/src/__tests__/AdminPanel.test.jsx
+++ b/ice-order-ui/src/__tests__/AdminPanel.test.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+jest.mock('../apiService.jsx', () => ({
+  apiService: {
+    get: jest.fn(),
+    delete: jest.fn(),
+    put: jest.fn()
+  }
+}));
+
+jest.mock('../utils/dateUtils', () => ({
+  getCurrentLocalDateISO: () => '2024-01-01',
+  getCurrentLocalMonthISO: () => '2024-01'
+}));
+
+import AdminPanel from '../AdminPanel.jsx';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('fetches and displays orders', async () => {
+  const order = { id: 1, customerName: 'Alice', createdAt: '2024-01-01T00:00:00Z', paymentType: 'Cash', items: [] };
+  const { apiService } = require('../apiService.jsx');
+  apiService.get.mockResolvedValueOnce([order]);
+  render(<AdminPanel />);
+  await screen.findByText('Alice');
+  expect(apiService.get).toHaveBeenCalledWith('/orders?date=2024-01-01');
+  expect(screen.getByText('1')).toBeInTheDocument();
+});
+
+test('filters orders by search term', async () => {
+  const orders = [
+    { id: 1, customerName: 'Alice', createdAt: '2024-01-01T00:00:00Z', paymentType: 'Cash', items: [] },
+    { id: 2, customerName: 'Bob', createdAt: '2024-01-01T00:00:00Z', paymentType: 'Debit', items: [] }
+  ];
+  const { apiService } = require('../apiService.jsx');
+  apiService.get.mockResolvedValueOnce(orders);
+  render(<AdminPanel />);
+  await screen.findByText('Alice');
+  const search = screen.getByPlaceholderText(/Search by ID or Name/i);
+  fireEvent.change(search, { target: { value: 'Bob' } });
+  expect(screen.getByText('Bob')).toBeInTheDocument();
+  expect(screen.queryByText('Alice')).not.toBeInTheDocument();
+});

--- a/ice-order-ui/src/__tests__/ItemTypeList.test.jsx
+++ b/ice-order-ui/src/__tests__/ItemTypeList.test.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ItemTypeList from '../inventory/ItemTypeList.jsx';
+
+test('shows empty message when no item types', () => {
+  render(<ItemTypeList itemTypes={[]} isLoading={false} onEdit={jest.fn()} onDelete={jest.fn()} />);
+  expect(screen.getByText(/ไม่พบประเภทวัสดุในคลัง/)).toBeInTheDocument();
+});
+
+test('calls edit and delete handlers', () => {
+  const itemTypes = [{ item_type_id: 1, type_name: 'Box', description: '' }];
+  const onEdit = jest.fn();
+  const onDelete = jest.fn();
+  render(<ItemTypeList itemTypes={itemTypes} isLoading={false} onEdit={onEdit} onDelete={onDelete} />);
+  fireEvent.click(screen.getByTitle('แก้ไขประเภทวัสดุ'));
+  expect(onEdit).toHaveBeenCalledWith(itemTypes[0]);
+  fireEvent.click(screen.getByTitle('ลบประเภทวัสดุ'));
+  expect(onDelete).toHaveBeenCalledWith(1);
+});

--- a/ice-order-ui/src/__tests__/NewOrder.test.jsx
+++ b/ice-order-ui/src/__tests__/NewOrder.test.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+jest.mock('../apiService.jsx', () => ({ apiService: { post: jest.fn() } }));
+
+import NewOrder from '../NewOrder.jsx';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  window.open = jest.fn();
+});
+
+const fillRequiredFields = () => {
+  fireEvent.change(screen.getByLabelText(/Customer Name/i), { target: { value: 'John' } });
+  fireEvent.change(screen.getByLabelText(/^ราคาของน้ำแข็งหลอด$/), { target: { value: '10' } });
+  fireEvent.change(screen.getByLabelText(/^จำนวนของน้ำแข็งหลอด$/), { target: { value: '2' } });
+  fireEvent.change(screen.getByLabelText(/Issuer/), { target: { value: 'admin' } });
+};
+
+test('shows validation error when price entered without quantity', async () => {
+  render(<NewOrder onOrderCreated={jest.fn()} />);
+  fireEvent.change(screen.getByLabelText(/Customer Name/i), { target: { value: 'John' } });
+  fireEvent.change(screen.getByLabelText(/^ราคาของน้ำแข็งหลอด$/), { target: { value: '5' } });
+  fireEvent.change(screen.getByLabelText(/Issuer/), { target: { value: 'admin' } });
+  fireEvent.click(screen.getByRole('button', { name: /ออกบิล/i }));
+  expect(await screen.findByText(/กรุณากรอกทั้งราคาและจำนวน/)).toBeInTheDocument();
+});
+
+test('submits order and calls callback', async () => {
+  const data = { id: 1, status: 'Created' };
+  const { apiService } = require('../apiService.jsx');
+  apiService.post.mockResolvedValueOnce(data);
+  const onCreated = jest.fn();
+  render(<NewOrder onOrderCreated={onCreated} />);
+  fillRequiredFields();
+  fireEvent.click(screen.getByRole('button', { name: /ออกบิล/i }));
+  await waitFor(() => expect(apiService.post).toHaveBeenCalled());
+  expect(onCreated).toHaveBeenCalledWith(data);
+});


### PR DESCRIPTION
## Summary
- add babel plugin for vite meta env handling
- extend React component tests

## Testing
- `npm test` in `ice-order-ui`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e99a4c91c832880ad5361af67fd2c