### PR TITLE
Add env configuration loader

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,4 +1,1 @@
-module.exports = {
-  JWT_SECRET: process.env.JWT_SECRET || 'your-very-strong-secret-key-for-dev-only',
-  GCS_BUCKET_NAME: process.env.GCS_BUCKET_NAME || 'your-gcs-bucket-name'
-};
+module.exports = require('./config');

--- a/config/index.js
+++ b/config/index.js
@@ -1,0 +1,17 @@
+const dotenv = require('dotenv');
+
+// Load environment variables from a .env file if present
+dotenv.config();
+
+const requiredVars = ['JWT_SECRET', 'GCS_BUCKET_NAME'];
+
+for (const name of requiredVars) {
+  if (!process.env[name]) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+}
+
+module.exports = {
+  JWT_SECRET: process.env.JWT_SECRET,
+  GCS_BUCKET_NAME: process.env.GCS_BUCKET_NAME
+};

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,7 +1,7 @@
 // Unified authentication middleware
 const jwt = require('jsonwebtoken');
 const db = require('../db/postgres');
-const { JWT_SECRET } = require('../config');
+const { JWT_SECRET } = require('../config/index.js');
 
 /**
  * Authentication middleware to verify the JWT token

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "body-parser": "^2.2.0",
         "cors": "^2.8.5",
         "date-fns": "^4.1.0",
+        "dotenv": "^17.2.0",
         "ejs": "^3.1.10",
         "exceljs": "^4.4.0",
         "express": "^5.1.0",
@@ -2711,6 +2712,18 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.0.tgz",
+      "integrity": "sha512-Q4sgBT60gzd0BB0lSyYD3xM4YxrXA9y4uBDof1JNYGzOXrQdQ6yX+7XIAqoFOGQFOTK1D3Hts5OllpxMDZFONQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "jest"
+    "test": "JWT_SECRET=test-secret GCS_BUCKET_NAME=test-bucket jest"
   },
   "keywords": [],
   "author": "",
@@ -15,6 +15,7 @@
     "body-parser": "^2.2.0",
     "cors": "^2.8.5",
     "date-fns": "^4.1.0",
+    "dotenv": "^17.2.0",
     "ejs": "^3.1.10",
     "exceljs": "^4.4.0",
     "express": "^5.1.0",

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -6,7 +6,7 @@ const db = require('../db/postgres');
 const router = express.Router();
 
 // Import JWT_SECRET from config
-const { JWT_SECRET } = require('../config');
+const { JWT_SECRET } = require('../config/index.js');
 
 /**
  * @route   POST /api/auth/login

--- a/routes/customers.js
+++ b/routes/customers.js
@@ -3,7 +3,7 @@ const express = require('express');
 const router = express.Router();
 const { query, getClient } = require('../db/postgres'); 
 const { authMiddleware, requireRole } = require('../middleware/auth');
-const { GCS_BUCKET_NAME } = require('../config');
+const { GCS_BUCKET_NAME } = require('../config/index.js');
 
 const { Storage } = require('@google-cloud/storage');
 const sharp = require('sharp');

--- a/routes/expenses.js
+++ b/routes/expenses.js
@@ -9,7 +9,7 @@ const sharp = require('sharp');
 const { v4: uuidv4 } = require('uuid');
 const multer = require('multer');
 
-const { GCS_BUCKET_NAME } = require('../config');
+const { GCS_BUCKET_NAME } = require('../config/index.js');
 
 const storage = multer.memoryStorage();
 const upload = multer({ 


### PR DESCRIPTION
## Summary
- add dotenv-based config loader under `config/index.js`
- export loader from `config.js`
- update routes and middleware to import from new config path
- include dotenv dependency and set default env vars for tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687ff3e1e038832880efce160b0acc77