### PR TITLE
Add request validation with express-validator

### DIFF
--- a/middleware/validate.js
+++ b/middleware/validate.js
@@ -1,0 +1,13 @@
+const { validationResult } = require('express-validator');
+
+module.exports = validations => async (req, res, next) => {
+  for (const validation of validations) {
+    await validation.run(req);
+  }
+
+  const errors = validationResult(req);
+  if (errors.isEmpty()) {
+    return next();
+  }
+  res.status(400).json({ errors: errors.array() });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "ejs": "^3.1.10",
         "exceljs": "^4.4.0",
         "express": "^5.1.0",
+        "express-validator": "^7.0.1",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.2",
         "pg": "^8.14.1",
@@ -3175,6 +3176,19 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-validator": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.2.1.tgz",
+      "integrity": "sha512-CjNE6aakfpuwGaHQZ3m8ltCG2Qvivd7RHtVMS/6nVxOM7xVGqr4bhflsm4+N5FP5zI7Zxp+Hae+9RE+o8e3ZOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "validator": "~13.12.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -4923,6 +4937,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
@@ -6926,6 +6946,15 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "pg": "^8.14.1",
     "sharp": "^0.34.2",
     "uuid": "^11.1.0",
-    "winston": "^3.17.0"
+    "winston": "^3.17.0",
+    "express-validator": "^7.0.1"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/routes/containerRoutes.js
+++ b/routes/containerRoutes.js
@@ -3,6 +3,8 @@ const router = express.Router();
 const { authMiddleware, requireRole } = require('../middleware/auth');
 const containerController = require('../controllers/containerController');
 const { SOME_CONFIG } = require('../config/index.js');
+const validate = require('../middleware/validate');
+const { body, param } = require('express-validator');
 
 router.get('/sizes', authMiddleware, requireRole(['admin','accountant','staff','manager']), containerController.getContainerSizes);
 router.post('/sizes', authMiddleware, requireRole(['admin','accountant','manager']), containerController.createContainerSize);
@@ -20,7 +22,16 @@ router.get('/items/:id', authMiddleware, requireRole(['admin','accountant','staf
 router.put('/items/:id', authMiddleware, requireRole(['admin','accountant','staff','manager']), containerController.updateContainer);
 router.delete('/items/:id', authMiddleware, requireRole(['admin','accountant']), containerController.deleteContainer);
 
-router.post('/items/:containerId/assign', authMiddleware, requireRole(['admin','accountant','staff','manager']), containerController.assignContainer);
+router.post(
+  '/items/:containerId/assign',
+  authMiddleware,
+  requireRole(['admin','accountant','staff','manager']),
+  validate([
+    param('containerId').isInt().withMessage('containerId must be an integer'),
+    body('customerId').isInt().withMessage('customerId is required')
+  ]),
+  containerController.assignContainer
+);
 router.put('/assignments/:assignmentId', authMiddleware, requireRole(['admin','manager','accountant','staff']), containerController.updateAssignment);
 router.put('/assignments/:assignmentId/return', authMiddleware, requireRole(['admin','accountant','staff','manager']), containerController.returnContainer);
 router.get('/items/:containerId/assignments', authMiddleware, requireRole(['admin','accountant','staff','manager']), containerController.getAssignmentsForContainer);

--- a/routes/customers.js
+++ b/routes/customers.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const router = express.Router();
 const { authMiddleware, requireRole } = require('../middleware/auth');
+const validate = require('../middleware/validate');
+const { body } = require('express-validator');
 const customerController = require('../controllers/customerController');
 const { GCS_BUCKET_NAME } = require('../config/index.js');
 
@@ -18,7 +20,12 @@ router.get('/:customerId/credit-payments', authMiddleware, requireRole(['admin',
 router.post('/credit-payments/:paymentId/void', authMiddleware, requireRole(['admin','manager']), customerController.voidCreditPayment);
 router.put('/credit-payments/:paymentId', authMiddleware, requireRole(['admin','manager']), customerController.editCreditPayment);
 
-router.post('/', authMiddleware, requireRole(['admin','accountant','manager','staff']), customerController.createCustomer);
+router.post('/',
+  authMiddleware,
+  requireRole(['admin','accountant','manager','staff']),
+  validate([body('name').notEmpty().withMessage('Name is required')]),
+  customerController.createCustomer
+);
 router.get('/', authMiddleware, requireRole(['admin','accountant','manager','staff']), customerController.listCustomers);
 router.get('/:id', authMiddleware, requireRole(['admin','accountant','manager','staff']), customerController.getCustomer);
 router.put('/:id', authMiddleware, requireRole(['admin','accountant','manager','staff']), customerController.updateCustomer);

--- a/tests/containerRoutes.test.js
+++ b/tests/containerRoutes.test.js
@@ -51,4 +51,18 @@ describe('container routes', () => {
     expect(res.statusCode).toBe(403);
     expect(containerController.createContainerSize).not.toHaveBeenCalled();
   });
+
+  test('POST /api/containers/items/1/assign validates body', async () => {
+    const res = await request(app).post('/api/containers/items/1/assign');
+    expect(res.statusCode).toBe(400);
+    expect(containerController.assignContainer).not.toHaveBeenCalled();
+  });
+
+  test('POST /api/containers/items/1/assign with data calls controller', async () => {
+    const res = await request(app)
+      .post('/api/containers/items/1/assign')
+      .send({ customerId: 5 });
+    expect(res.statusCode).toBe(200);
+    expect(containerController.assignContainer).toHaveBeenCalled();
+  });
 });

--- a/tests/customersRoutes.test.js
+++ b/tests/customersRoutes.test.js
@@ -37,9 +37,17 @@ describe('customer routes', () => {
   });
 
   test('POST /api/customers uses createCustomer', async () => {
-    const res = await request(app).post('/api/customers');
+    const res = await request(app)
+      .post('/api/customers')
+      .send({ name: 'Acme' });
     expect(res.statusCode).toBe(200);
     expect(customerController.createCustomer).toHaveBeenCalled();
+  });
+
+  test('POST /api/customers missing name returns 400', async () => {
+    const res = await request(app).post('/api/customers');
+    expect(res.statusCode).toBe(400);
+    expect(customerController.createCustomer).not.toHaveBeenCalled();
   });
 
 


### PR DESCRIPTION
## Summary
- add express-validator dependency and validation middleware
- validate customer creation and container assignment routes
- update related tests for validation errors

## Testing
- `JWT_SECRET=test GCS_BUCKET_NAME=test npx jest --runInBand --silent`

------
https://chatgpt.com/codex/tasks/task_e_687ffe11a37883288ee367771efca8a8