### PR TITLE
Switch components to modular API

### DIFF
--- a/ice-order-ui/src/AdminPanel.jsx
+++ b/ice-order-ui/src/AdminPanel.jsx
@@ -2,7 +2,8 @@
 // Refactored for Tailwind v4 principles, clarity, and UI improvements
 
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { apiService } from './apiService';
+import { request } from './api/base.js';
+import { handleComponentAuthError } from './api/helpers.js';
 
 import { getCurrentLocalDateISO, getCurrentLocalMonthISO } from './utils/dateUtils'; // Adjust path
 
@@ -575,7 +576,7 @@ export default function AdminPanel() {
         setError('');
         try {
             console.log(`Workspaceing orders for date: ${selectedDate}`);
-            const data = await apiService.get(`/orders?date=${selectedDate}`);
+            const { data } = await request(`/orders?date=${selectedDate}`);
             const processedOrders = (Array.isArray(data) ? data : []).map(o => ({
                 ...o,
                 items: Array.isArray(o.items) ? o.items : [],
@@ -602,7 +603,7 @@ export default function AdminPanel() {
         setError('');
         setSuccessMessage('');
         try {
-            await apiService.delete(`/orders/${id}`);
+            await request(`/orders/${id}`, 'DELETE');
             setSuccessMessage(`Order #${id} deleted successfully.`);
             setExpandedOrderId(null);
             fetchOrders(false); // Refetch
@@ -618,7 +619,7 @@ export default function AdminPanel() {
         setError('');
         setSuccessMessage('');
         try {
-            const result = await apiService.put(`/orders/${orderId}`, updatedData);
+            const { data: result } = await request(`/orders/${orderId}`, 'PUT', updatedData);
             setSuccessMessage(result?.message || `Order #${orderId} updated successfully.`);
             fetchOrders(false); // Refetch
             // No need to return Promise.resolve(), modal can close based on no error
@@ -638,7 +639,7 @@ export default function AdminPanel() {
         setError('');
         setSuccessMessage('');
         try {
-            const data = await apiService.get(`/reports/daily?date=${dailyDate}`);
+            const { data } = await request(`/reports/daily?date=${dailyDate}`);
             setDailyReport(data);
         } catch (err) {
             console.error("Daily report fetch error in AdminPanel:", err);
@@ -657,7 +658,7 @@ export default function AdminPanel() {
         setError('');
         setSuccessMessage('');
         try {
-            const data = await apiService.get(`/reports/monthly?month=${monthlyMonth}`);
+            const { data } = await request(`/reports/monthly?month=${monthlyMonth}`);
             setMonthlyReport(data);
         } catch (err) {
             console.error("Monthly report fetch error in AdminPanel:", err);

--- a/ice-order-ui/src/LoginPage.jsx
+++ b/ice-order-ui/src/LoginPage.jsx
@@ -1,7 +1,7 @@
 // 📁 src/LoginPage.jsx
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { apiService } from './apiService';
+import { auth } from './api/index.js';
 
 function LoginPage({ onLoginSuccess }) {
   const [username, setUsername] = useState('');
@@ -17,9 +17,9 @@ function LoginPage({ onLoginSuccess }) {
     
     try {
       console.log('Attempting login...');
-      const response = await apiService.post('/auth/login', { 
-        username, 
-        password 
+      const { data: response } = await auth.login({
+        username,
+        password
       });
       
       console.log('Login successful, response:', 

--- a/ice-order-ui/src/NewOrder.jsx
+++ b/ice-order-ui/src/NewOrder.jsx
@@ -1,6 +1,6 @@
 // 📁 File: NewOrder.js (Corrected CSS Grid for Product Alignment)
 import React, { useState, useRef, useEffect } from 'react';
-import { apiService } from './apiService'; // Adjust the import based on your project structure
+import { request } from './api/base.js';
 
 // Define the product names mapping
 const productNames = {
@@ -152,7 +152,7 @@ export default function NewOrder({ onOrderCreated }) {
 
     // --- API Call & Post-Submit Actions ---
     try {
-       const createdOrderData = await apiService.post('/orders', payload);
+       const { data: createdOrderData } = await request('/orders', 'POST', payload);
 
        if (!createdOrderData || !createdOrderData.id || !createdOrderData.status) {
            throw new Error('สร้างคำสั่งซื้อแล้ว แต่ข้อมูลที่ได้รับกลับมาจากเซิร์ฟเวอร์ไม่สมบูรณ์หรือไม่ถูกต้อง');

--- a/ice-order-ui/src/__tests__/AdminPanel.test.jsx
+++ b/ice-order-ui/src/__tests__/AdminPanel.test.jsx
@@ -1,13 +1,7 @@
 import React from 'react';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 
-jest.mock('../apiService.jsx', () => ({
-  apiService: {
-    get: jest.fn(),
-    delete: jest.fn(),
-    put: jest.fn()
-  }
-}));
+jest.mock('../api/base.js', () => ({ request: jest.fn() }));
 
 jest.mock('../utils/dateUtils', () => ({
   getCurrentLocalDateISO: () => '2024-01-01',
@@ -22,11 +16,11 @@ beforeEach(() => {
 
 test('fetches and displays orders', async () => {
   const order = { id: 1, customerName: 'Alice', createdAt: '2024-01-01T00:00:00Z', paymentType: 'Cash', items: [] };
-  const { apiService } = require('../apiService.jsx');
-  apiService.get.mockResolvedValueOnce([order]);
+  const { request } = require('../api/base.js');
+  request.mockResolvedValueOnce({ data: [order] });
   render(<AdminPanel />);
   await screen.findByText('Alice');
-  expect(apiService.get).toHaveBeenCalledWith('/orders?date=2024-01-01');
+  expect(request).toHaveBeenCalledWith('/orders?date=2024-01-01');
   expect(screen.getByText('1')).toBeInTheDocument();
 });
 
@@ -35,8 +29,8 @@ test('filters orders by search term', async () => {
     { id: 1, customerName: 'Alice', createdAt: '2024-01-01T00:00:00Z', paymentType: 'Cash', items: [] },
     { id: 2, customerName: 'Bob', createdAt: '2024-01-01T00:00:00Z', paymentType: 'Debit', items: [] }
   ];
-  const { apiService } = require('../apiService.jsx');
-  apiService.get.mockResolvedValueOnce(orders);
+  const { request } = require('../api/base.js');
+  request.mockResolvedValueOnce({ data: orders });
   render(<AdminPanel />);
   await screen.findByText('Alice');
   const search = screen.getByPlaceholderText(/Search by ID or Name/i);

--- a/ice-order-ui/src/__tests__/LoginPage.test.jsx
+++ b/ice-order-ui/src/__tests__/LoginPage.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-jest.mock('../apiService.jsx', () => ({ apiService: {} }));
+jest.mock('../api/auth.js', () => ({ login: jest.fn() }));
 jest.mock('react-router-dom', () => ({ useNavigate: () => jest.fn() }));
 
 import LoginPage from '../LoginPage.jsx';

--- a/ice-order-ui/src/__tests__/NewOrder.test.jsx
+++ b/ice-order-ui/src/__tests__/NewOrder.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
-jest.mock('../apiService.jsx', () => ({ apiService: { post: jest.fn() } }));
+jest.mock('../api/base.js', () => ({ request: jest.fn() }));
 
 import NewOrder from '../NewOrder.jsx';
 
@@ -28,12 +28,12 @@ test('shows validation error when price entered without quantity', async () => {
 
 test('submits order and calls callback', async () => {
   const data = { id: 1, status: 'Created' };
-  const { apiService } = require('../apiService.jsx');
-  apiService.post.mockResolvedValueOnce(data);
+  const { request } = require('../api/base.js');
+  request.mockResolvedValueOnce({ data });
   const onCreated = jest.fn();
   render(<NewOrder onOrderCreated={onCreated} />);
   fillRequiredFields();
   fireEvent.click(screen.getByRole('button', { name: /ออกบิล/i }));
-  await waitFor(() => expect(apiService.post).toHaveBeenCalled());
+  await waitFor(() => expect(request).toHaveBeenCalled());
   expect(onCreated).toHaveBeenCalledWith(data);
 });

--- a/ice-order-ui/src/api/helpers.js
+++ b/ice-order-ui/src/api/helpers.js
@@ -1,0 +1,13 @@
+export function handleComponentAuthError(error, navigate) {
+    if (error && error.status === 401) {
+        localStorage.removeItem('authToken');
+        localStorage.removeItem('authUser');
+        if (navigate) {
+            navigate('/login');
+        } else {
+            window.location.replace('/login');
+        }
+        return true;
+    }
+    return false;
+}

--- a/ice-order-ui/src/api/index.js
+++ b/ice-order-ui/src/api/index.js
@@ -3,3 +3,4 @@ export { request } from './base.js';
 export * as customers from './customers.js';
 export * as containers from './containers.js';
 export * as credits from './credits.js';
+export { handleComponentAuthError } from './helpers.js';

--- a/ice-order-ui/src/crm/ContainerAssignmentManager.jsx
+++ b/ice-order-ui/src/crm/ContainerAssignmentManager.jsx
@@ -8,7 +8,7 @@ import {
     assignIceContainer,
     updateAssignmentDetails,
 } from '../api/containers.js';
-import { apiService } from '../apiService';
+import { handleComponentAuthError } from '../api/helpers.js';
 import ContainerAssignmentList from './ContainerAssignmentList';
 import ReturnContainerForm from './ReturnContainerForm';
 import CreateAssignmentModal from './CreateAssignmentModal';
@@ -138,7 +138,7 @@ export default function ContainerAssignmentManager() {
         } catch (err) {
             console.error("Failed to fetch assignments:", err);
             setError(err.data?.error || err.message || 'ไม่สามารถโหลดการมอบหมายได้');
-            if (err.status === 401) apiService.handleComponentAuthError(err, () => window.location.replace('/login'));
+            if (err.status === 401) handleComponentAuthError(err, () => window.location.replace('/login'));
         } finally {
             setIsLoading(false);
         }

--- a/ice-order-ui/src/crm/CustomerManager.jsx
+++ b/ice-order-ui/src/crm/CustomerManager.jsx
@@ -1,6 +1,5 @@
 // src/crm/CustomerManager.jsx
 import React, { useState, useCallback } from 'react';
-import { apiService } from '../apiService';
 import CustomerList from './CustomerList';
 import CustomerForm from './CustomerForm';
 import useCustomerFilters from './hooks/useCustomerFilters';

--- a/ice-order-ui/src/crm/IceContainerManager.jsx
+++ b/ice-order-ui/src/crm/IceContainerManager.jsx
@@ -8,7 +8,7 @@ import {
     assignIceContainer,
     retireIceContainer,
 } from '../api/containers.js';
-import { apiService } from '../apiService';
+import { handleComponentAuthError } from '../api/helpers.js';
 import IceContainerList from './IceContainerList'; 
 import IceContainerForm from './IceContainerForm'; 
 import AssignContainerForm from './AssignContainerForm'; 
@@ -108,14 +108,13 @@ export default function IceContainerManager() {
         } catch (err) {
             console.error("Failed to fetch ice containers:", err);
             setError(err.data?.error || err.message || 'ไม่สามรถโหลดถังน้ำแข็งได้.');
-            if (err.status === 401) apiService.handleComponentAuthError(err, () => window.location.replace('/login'));
+            if (err.status === 401) handleComponentAuthError(err, () => window.location.replace('/login'));
         } finally {
             setIsLoading(false);
         }
     // Add all reactive values from the component scope that are used inside the callback
     // State setters (setIsLoading, setError, etc.) are stable and usually don't need to be listed,
     // but including them satisfies the strictest interpretation of exhaustive-deps.
-    // apiService is an import, so it's stable.
     }, [
         pagination.page, // Used as fallback for pageArg
         pagination.limit, // Used directly for params.limit
@@ -136,7 +135,6 @@ export default function IceContainerManager() {
             }
         }
     // Dependencies are values from scope used inside.
-    // apiService is stable. setContainerSizes and setError are stable state setters.
     }, [containerSizes.length, isFormModalOpen, isAssignModalOpen, setContainerSizes, setError]);
 
     // --- Step 3: Add debouncing useEffect ---
@@ -258,7 +256,7 @@ export default function IceContainerManager() {
             } catch (err) {
                 console.error("Failed to retire container:", err);
                 setError(err.data?.error || err.message || "ไม่สามารถปลดระวางถังน้ำแข็งได้.");
-                if (err.status === 401) apiService.handleComponentAuthError(err, () => window.location.replace('/login'));
+                if (err.status === 401) handleComponentAuthError(err, () => window.location.replace('/login'));
             } finally {
                 setIsLoading(false);
                 setTimeout(() => setSuccessMessage(''), 4000);


### PR DESCRIPTION
## Summary
- add a helper for component level auth handling
- export the helper via api index
- refactor LoginPage and BillsList to use the modular API
- update several CRM and inventory managers to use `request`
- refactor AdminPanel, MainLayout and NewOrder for modular API
- update tests to mock the new modules

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880ab4c883483289ef2d8af4ce76038