### PR TITLE
Fix API URL echo in Dockerfile

### DIFF
--- a/ice-order-ui/Dockerfile
+++ b/ice-order-ui/Dockerfile
@@ -8,7 +8,7 @@ ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
 COPY package*.json ./
 RUN npm ci
 COPY . .
-RUN echo "Build-time Check API URL: $VITE_API_URL"
+RUN echo "Build-time Check API URL: $VITE_API_BASE_URL"
 RUN npm run build
 
 # Serve with nginx


### PR DESCRIPTION
## Summary
- fix environment variable name for API URL in Dockerfile

## Testing
- `npm test`
- `npm test` in `ice-order-ui`


------
https://chatgpt.com/codex/tasks/task_e_6883d00da4c08328a60c44057585489b