### PR TITLE
Use getConfig for env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Ice Delivery App
+
+This application loads configuration from environment variables via `getConfig()`
+located in `config/index.js`. Ensure all required variables are defined **before**
+any code calls `getConfig()`.
+
+Required variables:
+- `JWT_SECRET`
+- `GCS_BUCKET_NAME`
+- `DB_USER`
+- `DB_PASSWORD`
+- `DB_NAME`
+- `INSTANCE_CONNECTION_NAME`
+
+`DB_SOCKET_PATH` is optional.

--- a/config/index.js
+++ b/config/index.js
@@ -3,27 +3,20 @@ const dotenv = require('dotenv');
 // Load environment variables from a .env file if present
 dotenv.config();
 
-const requiredVars = [
-  'JWT_SECRET',
-  'GCS_BUCKET_NAME',
-  'DB_USER',
-  'DB_PASSWORD',
-  'DB_NAME',
-  'INSTANCE_CONNECTION_NAME'
-];
-
-for (const name of requiredVars) {
-  if (!process.env[name]) {
-    throw new Error(`Missing required environment variable: ${name}`);
-  }
+function getConfig() {
+  const required = ['JWT_SECRET', 'GCS_BUCKET_NAME', 'DB_USER', 'DB_PASSWORD', 'DB_NAME', 'INSTANCE_CONNECTION_NAME'];
+  required.forEach(name => {
+    if (!process.env[name]) throw new Error(`Missing required environment variable: ${name}`);
+  });
+  return {
+    JWT_SECRET: process.env.JWT_SECRET,
+    GCS_BUCKET_NAME: process.env.GCS_BUCKET_NAME,
+    DB_USER: process.env.DB_USER,
+    DB_PASSWORD: process.env.DB_PASSWORD,
+    DB_NAME: process.env.DB_NAME,
+    INSTANCE_CONNECTION_NAME: process.env.INSTANCE_CONNECTION_NAME,
+    DB_SOCKET_PATH: process.env.DB_SOCKET_PATH
+  };
 }
 
-module.exports = {
-  JWT_SECRET: process.env.JWT_SECRET,
-  GCS_BUCKET_NAME: process.env.GCS_BUCKET_NAME,
-  DB_USER: process.env.DB_USER,
-  DB_PASSWORD: process.env.DB_PASSWORD,
-  DB_NAME: process.env.DB_NAME,
-  INSTANCE_CONNECTION_NAME: process.env.INSTANCE_CONNECTION_NAME,
-  DB_SOCKET_PATH: process.env.DB_SOCKET_PATH
-};
+module.exports = { getConfig };

--- a/controllers/customerController.js
+++ b/controllers/customerController.js
@@ -2,7 +2,8 @@ const { query, getClient } = require('../db/postgres');
 const { Storage } = require('@google-cloud/storage');
 const sharp = require('sharp');
 const { v4: uuidv4 } = require('uuid');
-const { GCS_BUCKET_NAME } = require('../config/index.js');
+const { getConfig } = require('../config/index.js');
+const { GCS_BUCKET_NAME } = getConfig();
 
 const gcs = new Storage();
 const bucket = gcs.bucket(GCS_BUCKET_NAME);

--- a/db/postgres.js
+++ b/db/postgres.js
@@ -2,13 +2,14 @@
 // PostgreSQL connection module using pg Pool
 
 const { Pool } = require('pg');
+const { getConfig } = require('../config');
 const {
   DB_USER,
   DB_PASSWORD,
   DB_NAME,
   INSTANCE_CONNECTION_NAME,
   DB_SOCKET_PATH
-} = require('../config');
+} = getConfig();
 
 // Connection pool configuration - reads from config values
 // These variables should be set in your Cloud Run service configuration

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,7 +1,8 @@
 // Unified authentication middleware
 const jwt = require('jsonwebtoken');
 const db = require('../db/postgres');
-const { JWT_SECRET } = require('../config/index.js');
+const { getConfig } = require('../config/index.js');
+const { JWT_SECRET } = getConfig();
 const { logger } = require('./errorHandler');
 
 /**

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -5,8 +5,9 @@ const jwt = require('jsonwebtoken');
 const db = require('../db/postgres');
 const router = express.Router();
 
-// Import JWT_SECRET from config
-const { JWT_SECRET } = require('../config/index.js');
+// Import getConfig to access JWT_SECRET
+const { getConfig } = require('../config/index.js');
+const { JWT_SECRET } = getConfig();
 
 /**
  * @route   POST /api/auth/login

--- a/routes/customers.js
+++ b/routes/customers.js
@@ -4,7 +4,8 @@ const { authMiddleware, requireRole } = require('../middleware/auth');
 const validate = require('../middleware/validate');
 const { body } = require('express-validator');
 const customerController = require('../controllers/customerController');
-const { GCS_BUCKET_NAME } = require('../config/index.js');
+const { getConfig } = require('../config/index.js');
+const { GCS_BUCKET_NAME } = getConfig();
 
 router.get('/customers/search', authMiddleware, customerController.searchCustomers);
 router.get('/routes/:route_id/analytics', authMiddleware, customerController.getRouteAnalytics);

--- a/routes/expenses.js
+++ b/routes/expenses.js
@@ -10,7 +10,8 @@ const sharp = require('sharp');
 const { v4: uuidv4 } = require('uuid');
 const multer = require('multer');
 
-const { GCS_BUCKET_NAME } = require('../config/index.js');
+const { getConfig } = require('../config/index.js');
+const { GCS_BUCKET_NAME } = getConfig();
 
 const storage = multer.memoryStorage();
 const upload = multer({ 


### PR DESCRIPTION
## Summary
- read env vars at runtime using `getConfig`
- load config via `getConfig()` in authentication and database modules
- document required env vars before calling `getConfig()`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6883f52e64d883289f20961c2cff3e7e