### PR TITLE
Remove deprecated REACT_APP_API_BASE_URL

### DIFF
--- a/ice-order-ui/src/BillsList.jsx
+++ b/ice-order-ui/src/BillsList.jsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { request } from './api/base.js';
 
 // Constants
-const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || import.meta.env.VITE_API_BASE_URL || 'http://localhost:4000/api'; // Use env var
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:4000/api';
 const PAYMENT_TYPES = ['Cash', 'Debit', 'Credit'];
 
 // Mapping for display names

--- a/ice-order-ui/src/MainLayout.jsx
+++ b/ice-order-ui/src/MainLayout.jsx
@@ -13,8 +13,6 @@ import { CSS } from '@dnd-kit/utilities';
 import { request } from './api/base.js';
 
 // --- Constants ---
-// API_BASE_URL is primarily managed by the API helpers, but kept for reference.
-// const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || import.meta.env.VITE_API_BASE_URL || 'http://localhost:4000/api';
 const VALID_TARGET_COLUMNS = ['created', 'delivering', 'completed'];
 const STATUS_MAP = { created: 'Created', delivering: 'Out for Delivery', completed: 'Completed' };
 const POLLING_INTERVALS = { monitor: 60000 };

--- a/ice-order-ui/src/NewOrder.jsx
+++ b/ice-order-ui/src/NewOrder.jsx
@@ -12,7 +12,7 @@ const productNames = {
 };
 const productKeys = Object.keys(productNames); // ['A', 'B', 'C', 'D', 'E']
 
-const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || import.meta.env.VITE_API_BASE_URL || 'http://localhost:4000/api'; //var env
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:4000/api';
 
 // Default initial state for the form
 const initialFormState = {


### PR DESCRIPTION
## Summary
- remove references to `process.env.REACT_APP_API_BASE_URL`
- rely solely on `import.meta.env.VITE_API_BASE_URL`
- clean up comment in `MainLayout.jsx`

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6883fc00301083288f4749b2710ec232