### PR TITLE
Improve token error handling

### DIFF
--- a/ice-order-ui/src/LoginPage.jsx
+++ b/ice-order-ui/src/LoginPage.jsx
@@ -1,5 +1,5 @@
 // 📁 src/LoginPage.jsx
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { auth } from './api/index.js';
 
@@ -9,6 +9,14 @@ function LoginPage({ onLoginSuccess }) {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
+
+  useEffect(() => {
+    const msg = localStorage.getItem('authErrorMessage');
+    if (msg) {
+      setError(msg);
+      localStorage.removeItem('authErrorMessage');
+    }
+  }, []);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -31,17 +39,22 @@ function LoginPage({ onLoginSuccess }) {
       
       // Make sure we got a proper response with token
       if (!response || !response.token) {
-        throw new Error('Invalid response from server: missing token');
+        throw new Error(
+          'Invalid response from server: missing token. Check server logs or configuration.'
+        );
       }
       
       // Store token and call success handler
       localStorage.setItem('authToken', response.token);
       localStorage.setItem('authUser', JSON.stringify(response.user));
+      localStorage.removeItem('authErrorMessage');
       
       // Verify token was stored
       const storedToken = localStorage.getItem('authToken');
       if (!storedToken) {
-          throw new Error('Failed to store authentication token');
+          throw new Error(
+            'Failed to store authentication token. Check browser settings or server configuration.'
+          );
       }
       
       // Pass both user and token to the success handler

--- a/ice-order-ui/src/api/base.js
+++ b/ice-order-ui/src/api/base.js
@@ -13,6 +13,10 @@ export const debugToken = () => {
 export const handleGlobalAuthError = (status, endpoint) => {
     if (status === 401) {
         console.warn(`Unauthorized (401) response from ${endpoint}. Token may be invalid or expired. Redirecting to login.`);
+        localStorage.setItem(
+            'authErrorMessage',
+            'Could not verify your login token. Please log in again and check server logs or configuration if this continues.'
+        );
         const lastAuthErrorTime = parseInt(sessionStorage.getItem('lastAuthErrorTime') || '0');
         const now = Date.now();
         if (now - lastAuthErrorTime > 2000) {


### PR DESCRIPTION
## Summary
- log more details for invalid auth tokens
- help UI show when token verification fails

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68840a2f04608328b57db2f1c8625ac8