### PR TITLE
Implement customer DB handlers

### DIFF
--- a/tests/customersRoutes.test.js
+++ b/tests/customersRoutes.test.js
@@ -122,4 +122,94 @@ describe('customer routes', () => {
 
     expect(res.statusCode).toBe(400);
   });
+
+  test('GET /api/customers/customers/search returns matches', async () => {
+    db.query.mockResolvedValueOnce({ rows: [{ customer_id: 2 }] });
+    const res = await request(app).get('/api/customers/customers/search?search=a');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual([{ customer_id: 2 }]);
+  });
+
+  test('GET /api/customers/routes/1/analytics returns count', async () => {
+    db.query.mockResolvedValueOnce({ rows: [{ customer_count: '3' }] });
+    const res = await request(app).get('/api/customers/routes/1/analytics');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ route_id: 1, customer_count: 3 });
+  });
+
+  test('GET /api/customers/delivery-routes returns list', async () => {
+    db.query.mockResolvedValueOnce({ rows: [{ route_id: 1 }] });
+    const res = await request(app).get('/api/customers/delivery-routes');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual([{ route_id: 1 }]);
+  });
+
+  test('POST /api/customers/delivery-routes creates route', async () => {
+    db.query.mockResolvedValueOnce({ rows: [{ route_id: 1, route_name: 'A' }] });
+    const res = await request(app).post('/api/customers/delivery-routes').send({ route_name: 'A' });
+    expect(res.statusCode).toBe(201);
+    expect(res.body).toEqual({ route_id: 1, route_name: 'A' });
+  });
+
+  test('PUT /api/customers/delivery-routes/1 updates route', async () => {
+    db.query.mockResolvedValueOnce({ rows: [{ route_id: 1, route_name: 'B' }] });
+    const res = await request(app).put('/api/customers/delivery-routes/1').send({ route_name: 'B', is_active: false });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ route_id: 1, route_name: 'B' });
+  });
+
+  test('DELETE /api/customers/delivery-routes/1 removes route', async () => {
+    db.query.mockResolvedValueOnce({ rows: [{ route_id: 1 }] });
+    const res = await request(app).delete('/api/customers/delivery-routes/1');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ message: 'Route deleted', route_id: 1 });
+  });
+
+  test('GET /api/customers/1/credit-sales returns sales', async () => {
+    db.query.mockResolvedValueOnce({ rows: [{ sale_id: 9 }] });
+    const res = await request(app).get('/api/customers/1/credit-sales');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual([{ sale_id: 9 }]);
+  });
+
+  test('GET /api/customers/1/credit-payments returns payments', async () => {
+    db.query.mockResolvedValueOnce({ rows: [{ payment_id: 7 }] });
+    const res = await request(app).get('/api/customers/1/credit-payments');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual([{ payment_id: 7 }]);
+  });
+
+  test('POST /api/customers/credit-payments/2/void voids payment', async () => {
+    db.query.mockResolvedValueOnce({ rows: [{ payment_id: 2 }] });
+    const res = await request(app)
+      .post('/api/customers/credit-payments/2/void')
+      .send({ void_reason: 'err' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ payment_id: 2 });
+  });
+
+  test('PUT /api/customers/credit-payments/3 edits payment', async () => {
+    db.query.mockResolvedValueOnce({ rows: [{ payment_id: 3, amount_paid: 5 }] });
+    const res = await request(app)
+      .put('/api/customers/credit-payments/3')
+      .send({ amount_paid: 5 });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ payment_id: 3, amount_paid: 5 });
+  });
+
+  test('GET /api/customers lists customers', async () => {
+    db.query
+      .mockResolvedValueOnce({ rows: [{ customer_id: 1 }] })
+      .mockResolvedValueOnce({ rows: [{ count: '1' }] });
+    const res = await request(app).get('/api/customers');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ data: [{ customer_id: 1 }], pagination: { page: 1, limit: 20, totalItems: 1 } });
+  });
+
+  test('DELETE /api/customers/1 deactivates customer', async () => {
+    db.query.mockResolvedValueOnce({ rows: [{ customer_id: 1 }] });
+    const res = await request(app).delete('/api/customers/1');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ message: 'Customer deleted' });
+  });
 });


### PR DESCRIPTION
## Summary
- implement actual DB operations for customer routes
- add coverage for customer route endpoints

## Testing
- `npx cross-env JWT_SECRET=test-secret GCS_BUCKET_NAME=test-bucket DB_USER=test DB_PASSWORD=test DB_NAME=testdb INSTANCE_CONNECTION_NAME=test-instance jest --runInBand --silent`

------
https://chatgpt.com/codex/tasks/task_e_688425f6eeb883288c5a092414af534f