### PR TITLE
Add inventory metadata helper

### DIFF
--- a/ice-order-ui/src/apiService.jsx
+++ b/ice-order-ui/src/apiService.jsx
@@ -243,6 +243,12 @@ export const apiService = {
         const queryParams = new URLSearchParams(filters).toString();
         return apiService.get(`/inventory/consumables?${queryParams}`);
     },
+    getInventoryConsumablesWithMetadata: async (filters = {}) => {
+        const queryParams = new URLSearchParams(filters).toString();
+        const response = await apiService.getWithMetadata(`/inventory/consumables?${queryParams}`);
+        const { data, pagination } = response.data || {};
+        return { data, pagination };
+    },
     getInventoryConsumableById: (consumableId) => apiService.get(`/inventory/consumables/${consumableId}`),
     addInventoryConsumable: (consumableData) => apiService.post('/inventory/consumables', consumableData),
     updateInventoryConsumable: (consumableId, consumableData) => apiService.put(`/inventory/consumables/${consumableId}`, consumableData),

--- a/ice-order-ui/src/inventory/ConsumablesManager.jsx
+++ b/ice-order-ui/src/inventory/ConsumablesManager.jsx
@@ -1,6 +1,7 @@
 // Suggested path: src/inventory/ConsumablesManager.jsx
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { request } from '../api/base.js';
+import { apiService } from '../apiService';
 import { handleComponentAuthError } from '../api/helpers.js';
 
 // Import the actual components
@@ -87,11 +88,16 @@ export default function ConsumablesManager() {
                     delete params[key];
                 }
             });
-            const response = await request(`/inventory/consumables?${new URLSearchParams(params).toString()}`);
-            setConsumables(Array.isArray(response.data) ? response.data : []);
+            const { data, pagination: pag } = await apiService.getInventoryConsumablesWithMetadata(params);
+            if (Array.isArray(data)) {
+                setConsumables(data);
+            } else {
+                console.error('Expected an array of consumables but received:', data);
+                setConsumables([]);
+            }
             setPagination(prevPagination => ({
                 ...prevPagination,
-                ...(response.pagination || { page: 1, totalPages: 1, totalItems: 0 })
+                ...(pag || { page: 1, totalPages: 1, totalItems: 0 })
             }));
         } catch (err) {
             console.error("Failed to fetch consumables:", err);


### PR DESCRIPTION
## Summary
- add `getInventoryConsumablesWithMetadata` to the API service
- switch consumable manager to use the new helper
- log an error when returned data is not an array

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884379c9574832897a54ed2c76db630