### PR TITLE
Add storage domain to cors origins

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ app.use(cors({
     'http://localhost:5173',
     'http://localhost:3000',
     'https://phayayenice.com',
+    'https://storage.googleapis.com',
   ],
   credentials: true,
   allowedHeaders: [


### PR DESCRIPTION
## Summary
- add `https://storage.googleapis.com` to the CORS origin list
- verify CORS headers and run test suite

## Testing
- `npm test`
- `curl -I -H "Origin: https://storage.googleapis.com" http://localhost:4000/test-headers`

------
https://chatgpt.com/codex/tasks/task_e_68843ded64208328b8c2f8088a4d21c0