### PR TITLE
Add date filter to loading logs

### DIFF
--- a/controllers/salesOps/loadingLogs.js
+++ b/controllers/salesOps/loadingLogs.js
@@ -125,7 +125,7 @@ exports.createLoadingLogs = async (req, res, next) => {
 };
 
 exports.getLoadingLogs = async (req, res, next) => {
-    const { driver_id, route_id, load_type, batch_uuid } = req.query;
+    const { driver_id, route_id, load_type, batch_uuid, date } = req.query;
     const requesting_user_id = req.user.id;
 
     console.log(`[SalesOps API] GET /loading-logs - User: ${requesting_user_id}, Query: ${JSON.stringify(req.query)}`);
@@ -156,6 +156,10 @@ exports.getLoadingLogs = async (req, res, next) => {
     if (batch_uuid) {
         conditions.push(`ll.load_batch_uuid = $${paramIndex++}`);
         values.push(batch_uuid);
+    }
+    if (date) {
+        conditions.push(`DATE(ll.load_timestamp AT TIME ZONE 'Asia/Bangkok') = $${paramIndex++}`);
+        values.push(date);
     }
 
     if (conditions.length > 0) {

--- a/routes/salesOperations.js
+++ b/routes/salesOperations.js
@@ -18,6 +18,7 @@ router.post('/batch-returns', authMiddleware, requireRole(['admin','manager','st
 router.get('/reconciliation-summary', authMiddleware, requireRole(['admin','manager','staff','accountant']), salesOpsController.getReconciliationSummary);
 router.get('/products', authMiddleware, requireRole(['admin','manager','staff','accountant']), salesOpsController.getProducts);
 router.post('/loading-logs', authMiddleware, requireRole(['admin','manager','staff']), salesOpsController.createLoadingLogs);
+// Optional query parameters: driver_id, route_id, load_type, batch_uuid, date (YYYY-MM-DD)
 router.get('/loading-logs', authMiddleware, requireRole(['admin','manager','staff','accountant']), salesOpsController.getLoadingLogs);
 router.put('/loading-logs/batch/:batchUUID', authMiddleware, requireRole(['admin','manager','staff']), salesOpsController.updateLoadingLogBatch);
 router.post('/driver-daily-summaries', authMiddleware, requireRole(['admin','manager','staff']), salesOpsController.createDriverDailySummary);


### PR DESCRIPTION
## Summary
- allow date filter in SalesOps loading logs API
- document new optional query parameter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68844893fc48832891b867d132897fc7