### PR TITLE
Fix summary fetch

### DIFF
--- a/ice-order-ui/src/salesops/SalesEntryManager.jsx
+++ b/ice-order-ui/src/salesops/SalesEntryManager.jsx
@@ -66,8 +66,8 @@ export default function SalesEntryManager() {
         setEditingSale(null); // Reset editing state when loading a new day
 
         try {
-            const fetchedSummaries = await apiService.getDriverDailySummaries({ driver_id: selectedDriverId, sale_date: selectedDate });
-            let summaryToUse = fetchedSummaries[0] || null;
+            const { data: fetchedSummaries } = await apiService.getDriverDailySummaries({ driver_id: selectedDriverId, sale_date: selectedDate });
+            let summaryToUse = Array.isArray(fetchedSummaries) ? fetchedSummaries[0] : null;
 
             if (!summaryToUse) {
                 summaryToUse = await apiService.addDriverDailySummary({ driver_id: selectedDriverId, sale_date: selectedDate, route_id: selectedRouteId || null });


### PR DESCRIPTION
## Summary
- handle { data } format when fetching daily summaries

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68844aec9e6883289503ffad33fe9504