### PR TITLE
Use shared date helper for ISO formatting

### DIFF
--- a/ice-order-ui/src/expenses/ExpenseListManager.jsx
+++ b/ice-order-ui/src/expenses/ExpenseListManager.jsx
@@ -3,8 +3,9 @@ import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { apiService } from '../apiService'; 
 import { PlusIcon } from '../components/Icons';
 
-import ExpenseList from './ExpenseList'; 
-import ExpenseForm from './ExpenseForm'; 
+import ExpenseList from './ExpenseList';
+import ExpenseForm from './ExpenseForm';
+import { getISODate } from '../utils/dateUtils';
 
 const getDescriptionFromFormData = (formData) => {
     if (formData instanceof FormData) {
@@ -35,7 +36,7 @@ const FilterBadge = ({ label, isActive, onClick, color = 'indigo' }) => {
 // Quick Date Range Selector
 const QuickDateSelector = ({ onSelect, currentFilters }) => {
     const today = new Date();
-    const formatDate = (date) => date.toISOString().split('T')[0];
+    const formatDate = (date) => getISODate(date);
 
     const quickRanges = [
         {

--- a/ice-order-ui/src/expenses/ExpenseReports.jsx
+++ b/ice-order-ui/src/expenses/ExpenseReports.jsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { apiService } from '../apiService';
 import { DownloadIcon } from '../components/Icons';
+import { getISODate } from '../utils/dateUtils';
 
 // Helper functions
 const formatDate = (dateString) => {
@@ -166,7 +167,7 @@ const ReportSummarySection = ({ summary, insights }) => {
 // Quick Filter Badges
 const QuickFilterBadges = ({ onApplyQuickFilter, currentFilters }) => {
     const today = new Date();
-    const formatDateForFilter = (date) => date.toISOString().split('T')[0];
+    const formatDateForFilter = (date) => getISODate(date);
 
     const quickFilters = [
         {
@@ -306,7 +307,7 @@ const enhancedExportToCSV = (reportData, summary, insights) => {
     if (link.download !== undefined) {
         const url = URL.createObjectURL(blob);
         link.setAttribute("href", url);
-        link.setAttribute("download", `expense_report_enhanced_${new Date().toISOString().split('T')[0]}.csv`);
+        link.setAttribute("download", `expense_report_enhanced_${getISODate(new Date())}.csv`);
         link.style.visibility = 'hidden';
         document.body.appendChild(link);
         link.click();

--- a/ice-order-ui/src/factory/MaintenanceModal.jsx
+++ b/ice-order-ui/src/factory/MaintenanceModal.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { X, Wrench } from 'lucide-react';
+import { getISODate } from '../utils/dateUtils';
 
 const MaintenanceModal = ({ 
     isOpen, 
@@ -30,7 +31,7 @@ const MaintenanceModal = ({
 
     // Helper to get today's date in YYYY-MM-DD format
     const getTodayDate = () => {
-        return new Date().toISOString().split('T')[0];
+        return getISODate(new Date());
     };
 
     return (

--- a/ice-order-ui/src/factory/TireAssignmentModal.jsx
+++ b/ice-order-ui/src/factory/TireAssignmentModal.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { X, MapPin, Truck, Package } from 'lucide-react';
+import { getISODate } from '../utils/dateUtils';
 
 const TireAssignmentModal = ({ 
     isOpen, 
@@ -31,7 +32,7 @@ const TireAssignmentModal = ({
 
     // Helper to get today's date in YYYY-MM-DD format
     const getTodayDate = () => {
-        return new Date().toISOString().split('T')[0];
+        return getISODate(new Date());
     };
 
     // Standard vehicle tire positions

--- a/ice-order-ui/src/factory/TireFormModal.jsx
+++ b/ice-order-ui/src/factory/TireFormModal.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { X, Package } from 'lucide-react';
+import { getISODate } from '../utils/dateUtils';
 
 const TireFormModal = ({ 
     isOpen, 
@@ -30,7 +31,7 @@ const TireFormModal = ({
 
     // Helper to get today's date in YYYY-MM-DD format
     const getTodayDate = () => {
-        return new Date().toISOString().split('T')[0];
+        return getISODate(new Date());
     };
 
     // Common tire brands for quick selection

--- a/ice-order-ui/src/factory/WaterLogForm.jsx
+++ b/ice-order-ui/src/factory/WaterLogForm.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { X, Droplets, AlertTriangle, Sun, Moon, Calendar, Save } from 'lucide-react';
+import { getISODate } from '../utils/dateUtils';
 
 const WaterLogForm = ({ 
     isOpen, 
@@ -112,7 +113,7 @@ const WaterLogForm = ({
                                 value={selectedDate}
                                 onChange={(e) => setSelectedDate(e.target.value)}
                                 className="px-3 py-1 border border-blue-300 rounded focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                                max={new Date().toISOString().split('T')[0]}
+                                max={getISODate(new Date())}
                             />
                             <div className="ml-auto text-xs text-blue-700">
                                 <strong>Note:</strong> Empty fields will be skipped during submission

--- a/ice-order-ui/src/factory/WaterTestLogManager.jsx
+++ b/ice-order-ui/src/factory/WaterTestLogManager.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { Droplets, Plus, Calendar, AlertTriangle, X, BarChart3, Search, Filter } from 'lucide-react';
 import { apiService } from '../apiService';
+import { getISODate } from '../utils/dateUtils';
 
 
 import WaterDashboard from './WaterDashboard';
@@ -9,7 +10,7 @@ import WaterLogForm from './WaterLogForm';
 export default function WaterTestLogManager() {
     const [logs, setLogs] = useState([]);
     const [stages, setStages] = useState([]);
-    const [selectedDate, setSelectedDate] = useState(new Date().toISOString().split('T')[0]);
+    const [selectedDate, setSelectedDate] = useState(getISODate(new Date()));
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
     const [showLogForm, setShowLogForm] = useState(false);
@@ -84,7 +85,7 @@ export default function WaterTestLogManager() {
             const startDate = new Date();
             startDate.setDate(startDate.getDate() - 7);
             
-            const formatDate = (d) => d.toISOString().split('T')[0];
+            const formatDate = (d) => getISODate(d);
 
             const query = new URLSearchParams({
                 start_date: formatDate(startDate),

--- a/ice-order-ui/src/salesops/DailyOperationsManager.jsx
+++ b/ice-order-ui/src/salesops/DailyOperationsManager.jsx
@@ -2,7 +2,7 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { apiService } from '../apiService';
-import { getCurrentLocalDateISO, formatDisplayDate } from '../utils/dateUtils';
+import { getCurrentLocalDateISO, formatDisplayDate, getISODate } from '../utils/dateUtils';
 import { PlusIcon, EditIcon, CheckCircleIcon, PlayCircleIcon, DocumentTextIcon } from '../components/Icons';
 import LoadingLogForm from './LoadingLogForm';
 import ProductReturnModal from './ProductReturnModal';
@@ -62,7 +62,7 @@ const DriverDayCard = ({ driverLog, selectedDate, onOpenLoadingLog, onOpenReturn
         ? loading_logs
             .filter(log => {
                 // Filter to only include logs from the current selected date
-                const logDate = new Date(log.load_timestamp).toISOString().split('T')[0];
+                const logDate = getISODate(log.load_timestamp);
                 return logDate === selectedDate; // You'll need to pass selectedDate as a prop
             })
             .reduce((acc, log) => acc + log.items.reduce((sum, item) => sum + parseFloat(item.quantity_loaded || 0), 0), 0)


### PR DESCRIPTION
## Summary
- import `getISODate` in DailyOperationsManager and use it
- standardize date handling in ExpenseReports and ExpenseListManager
- update factory forms to use `getISODate`

## Testing
- `npm test --silent 2>&1 | tail -n 5`
- `(cd ice-order-ui && npm test --silent 2>&1 | tail -n 5)`

------
https://chatgpt.com/codex/tasks/task_e_68844e98cb3c8328b12234adc8b56ca4