### PR TITLE
Add sales ops loading logs route tests

### DIFF
--- a/tests/salesOperationsRoutes.test.js
+++ b/tests/salesOperationsRoutes.test.js
@@ -137,4 +137,25 @@ describe('sales operations routes', () => {
     expect(res.statusCode).toBe(403);
     expect(salesOpsController.createProductReturns).not.toHaveBeenCalled();
   });
+
+  test('GET /loading-logs with date query hits controller', async () => {
+    __setRole('admin');
+    const date = '2024-01-01';
+
+    const res = await request(app).get(`/api/sales-ops/loading-logs?date=${date}`);
+
+    expect(res.statusCode).toBe(200);
+    expect(salesOpsController.getLoadingLogs).toHaveBeenCalled();
+    const reqPassed = salesOpsController.getLoadingLogs.mock.calls[0][0];
+    expect(reqPassed.query.date).toBe(date);
+  });
+
+  test('GET /loading-logs unauthorized role', async () => {
+    __setRole('guest');
+
+    const res = await request(app).get('/api/sales-ops/loading-logs?date=2024-01-01');
+
+    expect(res.statusCode).toBe(403);
+    expect(salesOpsController.getLoadingLogs).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- cover GET `/loading-logs` in sales operations routes tests
- ensure controller receives `date` query param and unauthorized roles are blocked

## Testing
- `npm test -- -i`

------
https://chatgpt.com/codex/tasks/task_e_68844eba1e80832896160669e4c52351