### PR TITLE
Fix modal zoom reset

### DIFF
--- a/ice-order-ui/src/expenses/ExpenseList.jsx
+++ b/ice-order-ui/src/expenses/ExpenseList.jsx
@@ -54,7 +54,7 @@ const ReceiptModal = ({ isOpen, onClose, imageUrl, expenseDescription }) => {
         // Reset zoom and position when new image loads
         setZoomLevel(1);
         setImagePosition({ x: 0, y: 0 });
-    }, [imageUrl]);
+    }, [imageUrl, isOpen]);
 
     // Keyboard shortcuts and mouse events - MUST be called before any early returns
     useEffect(() => {


### PR DESCRIPTION
## Summary
- ensure receipt modal resets zoom when reopened by adding `isOpen` to `useEffect` dependency

## Testing
- `CI=true npm test --silent -- -i`

------
https://chatgpt.com/codex/tasks/task_e_68853df32a60832891d8f3076c3eab5b