### PR TITLE
Increase receipt modal width

### DIFF
--- a/ice-order-ui/src/Modal.jsx
+++ b/ice-order-ui/src/Modal.jsx
@@ -50,7 +50,7 @@ const Modal = ({ isOpen, onClose, title, children }) => {
             onMouseUp={handleOverlayMouseUp}   // Use onMouseUp
         >
             <div
-                className="bg-white p-6 rounded-lg shadow-xl w-full max-w-md transform transition-all duration-300 ease-in-out scale-95 opacity-0 animate-modalShow"
+                className="bg-white p-6 rounded-lg shadow-xl w-full max-w-md sm:max-w-4xl transform transition-all duration-300 ease-in-out scale-95 opacity-0 animate-modalShow"
             >
                 <div className="flex justify-between items-center mb-4 pb-3 border-b border-gray-200">
                     <h3 className="text-xl font-semibold text-gray-800">{title}</h3>

--- a/ice-order-ui/src/expenses/ExpenseList.jsx
+++ b/ice-order-ui/src/expenses/ExpenseList.jsx
@@ -157,7 +157,7 @@ const ReceiptModal = ({ isOpen, onClose, imageUrl, expenseDescription }) => {
                 ></div>
 
                 {/* Modal */}
-                <div className="relative inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-2xl sm:w-full">
+                <div className="relative inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-4xl sm:w-full">
                     {/* Header */}
                     <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
                         <div className="flex items-center justify-between">
@@ -198,7 +198,7 @@ const ReceiptModal = ({ isOpen, onClose, imageUrl, expenseDescription }) => {
                                 <img
                                     src={imageUrl}
                                     alt="ใบเสร็จ"
-                                    className={`max-w-full h-auto max-h-96 object-contain rounded ${imageLoading ? 'opacity-0' : 'opacity-100'} transition-opacity duration-300`}
+                                    className={`max-w-full h-auto max-h-[80vh] object-contain rounded ${imageLoading ? 'opacity-0' : 'opacity-100'} transition-opacity duration-300`}
                                     onLoad={handleImageLoad}
                                     onError={handleImageError}
                                     onMouseDown={handleMouseDown}


### PR DESCRIPTION
## Summary
- widen shared Modal component
- expand ExpenseList receipt viewer size

## Testing
- `npm test --silent` in `ice-order-ui`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68854f0df9d883289c5df934e9fa12ad