### PR TITLE
Handle 404 on initial water log load

### DIFF
--- a/ice-order-ui/src/factory/WaterTestLogManager.jsx
+++ b/ice-order-ui/src/factory/WaterTestLogManager.jsx
@@ -15,6 +15,7 @@ export default function WaterTestLogManager() {
     const [error, setError] = useState(null);
     const [showLogForm, setShowLogForm] = useState(false);
     const [showDashboard, setShowDashboard] = useState(true);
+    const [initialLoad, setInitialLoad] = useState(true);
     
     // Filter states
     const [searchTerm, setSearchTerm] = useState('');
@@ -59,7 +60,7 @@ export default function WaterTestLogManager() {
         }
     }, []);
 
-    const fetchLogs = useCallback(async (date) => {
+    const fetchLogs = useCallback(async (date, showWarning = true) => {
         setLoading(true);
         setError(null);
         try {
@@ -69,7 +70,9 @@ export default function WaterTestLogManager() {
             console.error('Error fetching water logs:', err);
             if (err.status === 404) {
                 setLogs([]);
-                setError('No water test log');
+                if (showWarning) {
+                    setError('No water test log');
+                }
             } else {
                 setError('Failed to fetch water logs. Please try again.');
             }
@@ -161,7 +164,8 @@ export default function WaterTestLogManager() {
     }, [fetchStages, fetchDashboardData]);
 
     useEffect(() => {
-        fetchLogs(selectedDate);
+        fetchLogs(selectedDate, !initialLoad);
+        setInitialLoad(false);
     }, [selectedDate, fetchLogs]);
 
     const resetForm = useCallback(() => {


### PR DESCRIPTION
## Summary
- track first load state in `WaterTestLogManager`
- suppress `No water test log` warning on first load

## Testing
- `npm test --silent` *(fails: Missing required environment variable: JWT_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_6885783df4108328b8e8271bc47b1393