### PR TITLE
Fix zoom boundaries for positive translation

### DIFF
--- a/ice-order-ui/src/hooks/useZoomPan.js
+++ b/ice-order-ui/src/hooks/useZoomPan.js
@@ -38,9 +38,9 @@ export const useZoomPan = (isOpen) => {
         // Calculate bounds to ensure MIN_VISIBLE_AREA pixels remain visible
         // This prevents the image from being dragged completely out of view
         const minX = containerDimensions.width - scaledWidth + MIN_VISIBLE_AREA;
-        const maxX = -MIN_VISIBLE_AREA;
+        const maxX = scaledWidth - containerDimensions.width - MIN_VISIBLE_AREA;
         const minY = containerDimensions.height - scaledHeight + MIN_VISIBLE_AREA;
-        const maxY = -MIN_VISIBLE_AREA;
+        const maxY = scaledHeight - containerDimensions.height - MIN_VISIBLE_AREA;
 
         return { minX, maxX, minY, maxY };
     }, [imageDimensions, containerDimensions, zoomLevel]);
@@ -248,9 +248,9 @@ export const useZoomPan = (isOpen) => {
             
             const bounds = {
                 minX: containerDimensions.width - scaledWidth + MIN_VISIBLE_AREA,
-                maxX: -MIN_VISIBLE_AREA,
+                maxX: scaledWidth - containerDimensions.width - MIN_VISIBLE_AREA,
                 minY: containerDimensions.height - scaledHeight + MIN_VISIBLE_AREA,
-                maxY: -MIN_VISIBLE_AREA
+                maxY: scaledHeight - containerDimensions.height - MIN_VISIBLE_AREA
             };
             
             let clampedX = newPosX;


### PR DESCRIPTION
## Summary
- adjust bounds calculations in `useZoomPan` so images can translate in both directions
- apply same fix to wheel zoom calculations

## Testing
- `npx cross-env JWT_SECRET=test-secret GCS_BUCKET_NAME=test-bucket DB_USER=test DB_PASSWORD=test DB_NAME=testdb INSTANCE_CONNECTION_NAME=test-instance jest --runInBand --silent`
- `npm test` in `ice-order-ui`

------
https://chatgpt.com/codex/tasks/task_e_68860daff368832888b6d18cbc01f153