### PR TITLE
Fix zoom pan bounds

### DIFF
--- a/ice-order-ui/src/__tests__/useZoomPan.test.js
+++ b/ice-order-ui/src/__tests__/useZoomPan.test.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { useZoomPan } from '../hooks/useZoomPan.js';
+
+function TestViewer() {
+  const {
+    containerRef,
+    imageRef,
+    handleZoomIn,
+    handleImageLoad,
+    imageStyle,
+  } = useZoomPan(true);
+
+  return (
+    <div>
+      <button onClick={handleZoomIn}>zoom</button>
+      <div data-testid="container" ref={containerRef} style={{ width: 200, height: 200 }}>
+        <img
+          data-testid="img"
+          ref={imageRef}
+          onLoad={handleImageLoad}
+          src="test.jpg"
+          alt="test"
+          style={imageStyle}
+        />
+      </div>
+    </div>
+  );
+}
+
+describe('useZoomPan', () => {
+  test('allows panning after zoom', () => {
+    const { getByTestId, getByText } = render(<TestViewer />);
+    const img = getByTestId('img');
+    const container = getByTestId('container');
+
+    Object.defineProperty(img, 'naturalWidth', { value: 300 });
+    Object.defineProperty(img, 'naturalHeight', { value: 300 });
+    Object.defineProperty(container, 'offsetWidth', { value: 200 });
+    Object.defineProperty(container, 'offsetHeight', { value: 200 });
+
+    fireEvent.load(img);
+
+    const zoomBtn = getByText('zoom');
+    for (let i = 0; i < 6; i++) {
+      fireEvent.click(zoomBtn);
+    }
+
+    fireEvent.mouseDown(container, { button: 0, clientX: 100, clientY: 100 });
+    fireEvent.mouseMove(document, { clientX: 1000, clientY: 1000 });
+    fireEvent.mouseUp(document);
+
+    const transformAfterDrag = img.style.transform;
+    expect(transformAfterDrag).toBe('translate(380px, 380px) scale(2.1)');
+
+    fireEvent.mouseDown(container, { button: 0, clientX: 100, clientY: 100 });
+    fireEvent.mouseMove(document, { clientX: -1000, clientY: -1000 });
+    fireEvent.mouseUp(document);
+
+    const transformAfterDrag2 = img.style.transform;
+    expect(transformAfterDrag2).toBe('translate(-380px, -380px) scale(2.1)');
+  });
+});

--- a/ice-order-ui/src/hooks/useZoomPan.js
+++ b/ice-order-ui/src/hooks/useZoomPan.js
@@ -35,12 +35,17 @@ export const useZoomPan = (isOpen) => {
         const scaledWidth = imageDimensions.width * zoomLevel;
         const scaledHeight = imageDimensions.height * zoomLevel;
 
-        // Calculate bounds to ensure MIN_VISIBLE_AREA pixels remain visible
-        // This prevents the image from being dragged completely out of view
-        const minX = containerDimensions.width - scaledWidth + MIN_VISIBLE_AREA;
-        const maxX = scaledWidth - containerDimensions.width - MIN_VISIBLE_AREA;
-        const minY = containerDimensions.height - scaledHeight + MIN_VISIBLE_AREA;
-        const maxY = scaledHeight - containerDimensions.height - MIN_VISIBLE_AREA;
+        // Allow dragging even when the image isn't large enough to keep
+        // MIN_VISIBLE_AREA visible on both sides.
+        const excessX = Math.max(0, scaledWidth - containerDimensions.width);
+        const excessY = Math.max(0, scaledHeight - containerDimensions.height);
+        const visibleX = Math.min(MIN_VISIBLE_AREA, excessX / 2);
+        const visibleY = Math.min(MIN_VISIBLE_AREA, excessY / 2);
+
+        const minX = containerDimensions.width - scaledWidth + visibleX;
+        const maxX = scaledWidth - containerDimensions.width - visibleX;
+        const minY = containerDimensions.height - scaledHeight + visibleY;
+        const maxY = scaledHeight - containerDimensions.height - visibleY;
 
         return { minX, maxX, minY, maxY };
     }, [imageDimensions, containerDimensions, zoomLevel]);
@@ -245,12 +250,17 @@ export const useZoomPan = (isOpen) => {
             // Need to manually calculate bounds with new zoom for immediate update
             const scaledWidth = imageDimensions.width * newZoom;
             const scaledHeight = imageDimensions.height * newZoom;
-            
+
+            const excessX = Math.max(0, scaledWidth - containerDimensions.width);
+            const excessY = Math.max(0, scaledHeight - containerDimensions.height);
+            const visibleX = Math.min(MIN_VISIBLE_AREA, excessX / 2);
+            const visibleY = Math.min(MIN_VISIBLE_AREA, excessY / 2);
+
             const bounds = {
-                minX: containerDimensions.width - scaledWidth + MIN_VISIBLE_AREA,
-                maxX: scaledWidth - containerDimensions.width - MIN_VISIBLE_AREA,
-                minY: containerDimensions.height - scaledHeight + MIN_VISIBLE_AREA,
-                maxY: scaledHeight - containerDimensions.height - MIN_VISIBLE_AREA
+                minX: containerDimensions.width - scaledWidth + visibleX,
+                maxX: scaledWidth - containerDimensions.width - visibleX,
+                minY: containerDimensions.height - scaledHeight + visibleY,
+                maxY: scaledHeight - containerDimensions.height - visibleY
             };
             
             let clampedX = newPosX;


### PR DESCRIPTION
## Summary
- adjust zoom pan bounds to allow dragging even when the zoomed image is only slightly larger than its container
- calculate bounds during scroll zoom using the same logic
- add regression test for zooming and dragging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886635784848328b0f25f7c698f4c25