### PR TITLE
Fix receipt modal size

### DIFF
--- a/ice-order-ui/src/expenses/ExpenseList.jsx
+++ b/ice-order-ui/src/expenses/ExpenseList.jsx
@@ -75,7 +75,7 @@ const ReceiptModal = ({ isOpen, onClose, imageUrl, expenseDescription }) => {
                 <div className="fixed inset-0 bg-gray-900 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
 
                 {/* Modal Content */}
-                <div className="relative bg-white rounded-lg shadow-xl w-full max-w-6xl max-h-[90vh] flex flex-col">
+                <div className="relative bg-white rounded-lg shadow-xl w-full max-w-6xl max-h-[85vh] flex flex-col">
                     {/* Header */}
                     <div className="bg-white px-6 py-4 border-b border-gray-200 flex items-center justify-between">
                         <div className="flex-1">


### PR DESCRIPTION
## Summary
- ensure receipt modal fits within viewport without scroll

## Testing
- `npx cross-env JWT_SECRET=test-secret GCS_BUCKET_NAME=test-bucket DB_USER=test DB_PASSWORD=test DB_NAME=testdb INSTANCE_CONNECTION_NAME=test-instance jest --runInBand --silent`
- `npm test --silent` in `ice-order-ui`


------
https://chatgpt.com/codex/tasks/task_e_68866be42d3c8328920a305318effee3