### PR TITLE
Ensure water log form handles hardness field

### DIFF
--- a/ice-order-ui/src/factory/WaterTestLogManager.jsx
+++ b/ice-order-ui/src/factory/WaterTestLogManager.jsx
@@ -182,8 +182,8 @@ export default function WaterTestLogManager() {
         const reset = {};
         stages.forEach(stage => {
             reset[stage.stage_id] = {
-                morning: { ph_value: '', tds_ppm_value: '', ec_us_cm_value: '' },
-                afternoon: { ph_value: '', tds_ppm_value: '', ec_us_cm_value: '' }
+                morning: { ph_value: '', tds_ppm_value: '', ec_us_cm_value: '', hardness_mg_l_caco3: '' },
+                afternoon: { ph_value: '', tds_ppm_value: '', ec_us_cm_value: '', hardness_mg_l_caco3: '' }
             };
         });
         setFormData(reset);
@@ -204,7 +204,8 @@ export default function WaterTestLogManager() {
                     existingData[log.stage_id][sessionKey] = {
                         ph_value: log.ph_value || '',
                         tds_ppm_value: log.tds_ppm_value || '',
-                        ec_us_cm_value: log.ec_us_cm_value || ''
+                        ec_us_cm_value: log.ec_us_cm_value || '',
+                        hardness_mg_l_caco3: log.hardness_mg_l_caco3 || ''
                     };
                 });
                 setFormData(existingData);


### PR DESCRIPTION
## Summary
- reset water test form with hardness field for all sessions
- load existing hardness values when editing logs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893f332056483288c9b67ef6dc491a7