### PR TITLE
Convert water test log inputs to numeric values

### DIFF
--- a/ice-order-ui/src/factory/WaterTestLogManager.jsx
+++ b/ice-order-ui/src/factory/WaterTestLogManager.jsx
@@ -234,10 +234,10 @@ export default function WaterTestLogManager() {
                             stage_id: parseInt(stageId),
                             test_session: session.charAt(0).toUpperCase() + session.slice(1),
                             test_timestamp: new Date(`${selectedDate}T${session === 'morning' ? '08:00:00' : '14:00:00'}Z`).toISOString(),
-                            ph_value: sessionData.ph_value || null,
-                            tds_ppm_value: sessionData.tds_ppm_value || null,
-                            ec_us_cm_value: sessionData.ec_us_cm_value || null,
-                            hardness_mg_l_caco3: sessionData.hardness_mg_l_caco3 || null
+                            ph_value: sessionData.ph_value === '' ? null : Number(sessionData.ph_value),
+                            tds_ppm_value: sessionData.tds_ppm_value === '' ? null : Number(sessionData.tds_ppm_value),
+                            ec_us_cm_value: sessionData.ec_us_cm_value === '' ? null : Number(sessionData.ec_us_cm_value),
+                            hardness_mg_l_caco3: sessionData.hardness_mg_l_caco3 === '' ? null : Number(sessionData.hardness_mg_l_caco3)
                         });
                     }
                 });


### PR DESCRIPTION
## Summary
- ensure water test log submissions convert empty strings to null and numeric strings to numbers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893fa8e8e748328b009c466a855f778