### PR TITLE
Fix water log insert parameters

### DIFF
--- a/controllers/waterController.js
+++ b/controllers/waterController.js
@@ -42,10 +42,10 @@ exports.addWaterLog = async (req, res) => {
     try{
         const query =`
             INSERT INTO water_quality_logs
-                        (stage_id, test_session, test_timestamp, 
-                        ph_value, tds_ppm_value, ec_us_cm_value, hardness_mg_l_caco3, 
+                        (stage_id, test_session, test_timestamp,
+                        ph_value, tds_ppm_value, ec_us_cm_value, hardness_mg_l_caco3,
                         recorded_by_user_id)
-            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
             RETURNING *
         `;
         const { rows } = await db.query(query, [


### PR DESCRIPTION
## Summary
- include recorded_by_user_id as $8 in water log insert

## Testing
- `npm test`
- `psql "host=/cloudsql/test-instance dbname=testdb user=test" -c "SELECT column_name FROM information_schema.columns WHERE table_name='water_quality_logs';"` *(fails: No such file or directory)*
- `JWT_SECRET=test GCS_BUCKET_NAME=test DB_USER=test DB_PASSWORD=test DB_NAME=testdb INSTANCE_CONNECTION_NAME=test-instance node index.js`

------
https://chatgpt.com/codex/tasks/task_e_689413e8a5e48328909cfb77b4ec1ee6