### PR TITLE
feat: align RO stage detection and hardness logging

### DIFF
--- a/ice-order-ui/src/factory/WaterLogForm.jsx
+++ b/ice-order-ui/src/factory/WaterLogForm.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { X, Droplets, AlertTriangle, Sun, Moon, Calendar, Save } from 'lucide-react';
 import { getISODate } from '../utils/dateUtils';
+import { isROStage } from '../utils/stageUtils';
 
 const WaterLogForm = ({
     isOpen, 
@@ -16,7 +17,7 @@ const WaterLogForm = ({
 }) => {
     if (!isOpen) return null;
 
-    const isROStage = (stage) => stage?.stage_name?.toLowerCase().includes('reverse osmosis') || stage?.stage_id === 5;
+    // Determine whether any stage is RO to conditionally show hardness input
     const showHardness = stages.some(isROStage);
 
     const handleInputChange = (stageId, session, parameter, value) => {

--- a/ice-order-ui/src/factory/WaterTestLogManager.jsx
+++ b/ice-order-ui/src/factory/WaterTestLogManager.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { Droplets, Plus, Calendar, AlertTriangle, X, BarChart3, Search, Filter } from 'lucide-react';
 import { apiService } from '../apiService';
 import { getISODate } from '../utils/dateUtils';
+import { isROStage } from '../utils/stageUtils';
 
 import WaterDashboard from './WaterDashboard';
 import WaterLogForm from './WaterLogForm';
@@ -40,7 +41,10 @@ export default function WaterTestLogManager() {
         hardness_mg_l_caco3: { min: 50, max: 170, unit: 'mg/L CaCO₃' }
     };
 
-    const isROStage = (stage) => stage?.stage_name?.toLowerCase().includes('ro') || stage?.stage_id === 4;
+    // Determine if a water treatment stage should be treated as RO
+    // A stage is considered RO if its name contains "reverse osmosis",
+    // is exactly "ro", or has a stage_id of 5
+    // Uses the shared isROStage utility for consistency across components
 
     const fetchStages = useCallback(async () => {
         try {

--- a/ice-order-ui/src/utils/stageUtils.js
+++ b/ice-order-ui/src/utils/stageUtils.js
@@ -1,0 +1,7 @@
+const isROStage = (stage) => {
+  if (!stage) return false;
+  const name = stage.stage_name?.toLowerCase() || '';
+  return name.includes('reverse osmosis') || name === 'ro' || stage.stage_id === 5;
+};
+
+module.exports = { isROStage };

--- a/tests/waterController.test.js
+++ b/tests/waterController.test.js
@@ -1,0 +1,44 @@
+const waterController = require('../controllers/waterController');
+const db = require('../db/postgres');
+
+jest.mock('../db/postgres', () => ({
+  query: jest.fn()
+}));
+
+describe('waterController.addWaterLog', () => {
+  test('records hardness value for RO stage', async () => {
+    const req = {
+      body: {
+        stage_id: 5,
+        test_session: 'Morning',
+        test_timestamp: '2024-01-01T08:00:00Z',
+        ph_value: 7.0,
+        tds_ppm_value: 50,
+        ec_us_cm_value: 100,
+        hardness_mg_l_caco3: 120
+      },
+      user: { id: 1 }
+    };
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    };
+
+    db.query.mockResolvedValue({ rows: [{}] });
+
+    await waterController.addWaterLog(req, res);
+
+    expect(db.query).toHaveBeenCalledWith(expect.any(String), [
+      5,
+      'Morning',
+      '2024-01-01T08:00:00Z',
+      7.0,
+      50,
+      100,
+      120,
+      1
+    ]);
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+});

--- a/tests/waterRoutes.test.js
+++ b/tests/waterRoutes.test.js
@@ -38,9 +38,10 @@ describe('water routes', () => {
 
   test('POST /logs adds log', async () => {
     waterController.addWaterLog.mockImplementation((req, res) => res.status(201).json({ id: 1 }));
-    const res = await request(app).post('/api/water/logs');
+    const res = await request(app).post('/api/water/logs').send({ hardness_mg_l_caco3: 120 });
     expect(res.statusCode).toBe(201);
     expect(waterController.addWaterLog).toHaveBeenCalled();
+    expect(waterController.addWaterLog.mock.calls[0][0].body.hardness_mg_l_caco3).toBe(120);
   });
 
   test('GET /logs/recent calls controller', async () => {


### PR DESCRIPTION
## Summary
- centralize RO stage detection logic
- show hardness inputs and send numeric values for RO stage
- test that water logs include hardness for RO stages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895609f8f288328b7797abc5f728e54