### PR TITLE
Remove duplicate water log check and use server messages

### DIFF
--- a/ice-order-ui/src/factory/WaterTestLogManager.jsx
+++ b/ice-order-ui/src/factory/WaterTestLogManager.jsx
@@ -74,7 +74,7 @@ export default function WaterTestLogManager() {
             setFormData(initialFormData);
         } catch (err) {
             console.error('Error fetching stages:', err);
-            setError('ไม่สามารถโหลดข้อมูลขั้นตอนการตรวจสอบได้');
+            setError(err.response?.data?.message || 'ไม่สามารถโหลดข้อมูลขั้นตอนการตรวจสอบได้');
         }
     }, []);
 
@@ -89,10 +89,10 @@ export default function WaterTestLogManager() {
             if (err.status === 404) {
                 setLogs([]);
                 if (showWarning) {
-                    setError('ไม่มีบันทึกการตรวจสอบน้ำ');
+                    setError(err.response?.data?.message || 'ไม่มีบันทึกการตรวจสอบน้ำ');
                 }
             } else {
-                setError('ไม่สามารถโหลดบันทึกการตรวจสอบน้ำได้ กรุณาลองใหม่อีกครั้ง');
+                setError(err.response?.data?.message || 'ไม่สามารถโหลดบันทึกการตรวจสอบน้ำได้ กรุณาลองใหม่อีกครั้ง');
             }
         } finally {
             setLoading(false);
@@ -334,11 +334,7 @@ useEffect(() => {
         
     } catch (err) {
         console.error('Failed to update water test logs:', err);
-        if (err.response?.data?.code === 'DUPLICATE_ENTRY') {
-            setError('มีข้อมูลการตรวจสอบในวันนี้แล้ว กรุณาใช้ฟังก์ชันแก้ไขแทน');
-        } else {
-            setError('ไม่สามารถบันทึกผลการตรวจสอบได้ กรุณาลองใหม่อีกครั้ง');
-        }
+        setError(err.response?.data?.message || 'ไม่สามารถบันทึกผลการตรวจสอบได้ กรุณาลองใหม่อีกครั้ง');
     } finally {
         setLoading(false);
     }


### PR DESCRIPTION
## Summary
- Remove hard-coded `DUPLICATE_ENTRY` logic from WaterTestLogManager
- Surface backend-provided error messages in stage and log fetches and water log updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689575236b0c8328832f8214eabcb611