### PR TITLE
Prevent duplicate water logs

### DIFF
--- a/tests/waterController.test.js
+++ b/tests/waterController.test.js
@@ -6,6 +6,9 @@ jest.mock('../db/postgres', () => ({
 }));
 
 describe('waterController.addWaterLog', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
   test('records hardness value for RO stage', async () => {
     const req = {
       body: {
@@ -25,11 +28,15 @@ describe('waterController.addWaterLog', () => {
       json: jest.fn()
     };
 
-    db.query.mockResolvedValue({ rows: [{}] });
+    db.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{}] });
 
     await waterController.addWaterLog(req, res);
 
-    expect(db.query).toHaveBeenCalledWith(expect.any(String), [
+    expect(db.query).toHaveBeenCalledTimes(2);
+    expect(db.query).toHaveBeenNthCalledWith(1, expect.any(String), [5, 'Morning', '2024-01-01']);
+    expect(db.query).toHaveBeenNthCalledWith(2, expect.any(String), [
       5,
       'Morning',
       '2024-01-01T08:00:00Z',
@@ -40,5 +47,33 @@ describe('waterController.addWaterLog', () => {
       1
     ]);
     expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  test('returns 409 if log already exists', async () => {
+    const req = {
+      body: {
+        stage_id: 5,
+        test_session: 'Morning',
+        test_timestamp: '2024-01-01T08:00:00Z',
+        ph_value: 7.0,
+        tds_ppm_value: 50,
+        ec_us_cm_value: 100,
+        hardness_mg_l_caco3: 120
+      },
+      user: { id: 1 }
+    };
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    };
+
+    db.query.mockResolvedValueOnce({ rows: [{}] });
+
+    await waterController.addWaterLog(req, res);
+
+    expect(db.query).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Log already exists for this stage, session, and date' });
   });
 });


### PR DESCRIPTION
## Summary
- avoid duplicate water quality logs by checking for existing stage/session/date entries before insertion
- test coverage for success and duplicate scenarios in waterController.addWaterLog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68957daf6768832882d2a12d670a52d5