### PR TITLE
Validate water test sessions and surface errors

### DIFF
--- a/ice-order-ui/src/factory/WaterTestLogManager.jsx
+++ b/ice-order-ui/src/factory/WaterTestLogManager.jsx
@@ -334,7 +334,10 @@ useEffect(() => {
         
     } catch (err) {
         console.error('Failed to update water test logs:', err);
-        setError(err.response?.data?.message || 'ไม่สามารถบันทึกผลการตรวจสอบได้ กรุณาลองใหม่อีกครั้ง');
+        const message = err.status === 400
+            ? (err.data?.message || 'ข้อมูลไม่ถูกต้อง')
+            : (err.data?.message || 'ไม่สามารถบันทึกผลการตรวจสอบได้ กรุณาลองใหม่อีกครั้ง');
+        setError(message);
     } finally {
         setLoading(false);
     }


### PR DESCRIPTION
## Summary
- ensure backend water log upserts and inserts accept only Morning or Afternoon sessions, responding with 400 for unsupported values
- surface backend validation messages in water test log manager UI

## Testing
- `npm test`
- `cd ice-order-ui && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689580fcec4c8328acf3e88c14c5ed92