### PR TITLE
feat: omit test timestamp from water log upserts

### DIFF
--- a/controllers/waterController.js
+++ b/controllers/waterController.js
@@ -37,6 +37,7 @@ exports.getAllWaterLogs = async (req, res) => {
 };
 
 // Upsert method for updating/inserting water logs
+// test_timestamp is generated from the provided date and session; clients should omit it
 exports.upsertWaterLogs = async (req, res) => {
     const { date, logs } = req.body;
     const recorded_by_user_id = req.user.id;

--- a/ice-order-ui/src/factory/WaterTestLogManager.jsx
+++ b/ice-order-ui/src/factory/WaterTestLogManager.jsx
@@ -297,7 +297,6 @@ useEffect(() => {
                         const logEntry = {
                             stage_id: parseInt(stageId),
                             test_session: session.charAt(0).toUpperCase() + session.slice(1),
-                            test_timestamp: new Date(`${selectedDate}T${session === 'morning' ? '08:00:00' : '14:00:00'}Z`).toISOString(),
                             ph_value: sessionData.ph_value === '' ? null : Number(sessionData.ph_value),
                             tds_ppm_value: sessionData.tds_ppm_value === '' ? null : Number(sessionData.tds_ppm_value),
                             ec_us_cm_value: sessionData.ec_us_cm_value === '' ? null : Number(sessionData.ec_us_cm_value)

--- a/routes/water.js
+++ b/routes/water.js
@@ -8,8 +8,8 @@ router.route('/logs')
     .post(authMiddleware, waterController.addWaterLog) // Accessible by any authenticated user
     .delete(authMiddleware, requireRole(['admin']), waterController.deleteWaterLogsByDate);
 
-// NEW: Upsert (update/insert) water logs
-router.put('/logs/upsert', authMiddleware, waterController.upsertWaterLogs);    
+// Upsert (update/insert) water logs; timestamp derived from date and session
+router.put('/logs/upsert', authMiddleware, waterController.upsertWaterLogs);
 
 // Get recent water logs over a date range (defaults to last 7 days)
 router.route('/logs/recent')

--- a/tests/waterController.test.js
+++ b/tests/waterController.test.js
@@ -77,3 +77,60 @@ describe('waterController.addWaterLog', () => {
     expect(res.json).toHaveBeenCalledWith({ message: 'Log already exists for this stage, session, and date' });
   });
 });
+
+describe('waterController.upsertWaterLogs', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('upserts logs without test_timestamp in payload', async () => {
+    const req = {
+      body: {
+        date: '2024-01-01',
+        logs: [
+          {
+            stage_id: 1,
+            test_session: 'Morning',
+            ph_value: 7.1,
+            tds_ppm_value: 100,
+            ec_us_cm_value: 200,
+            hardness_mg_l_caco3: null
+          }
+        ]
+      },
+      user: { id: 1 }
+    };
+
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    };
+
+    const expectedTimestamp = new Date('2024-01-01T08:00:00Z').toISOString();
+
+    db.query
+      .mockResolvedValueOnce({}) // BEGIN
+      .mockResolvedValueOnce({ rows: [{}] }) // upsert query
+      .mockResolvedValueOnce({}); // COMMIT
+
+    await waterController.upsertWaterLogs(req, res);
+
+    expect(db.query).toHaveBeenNthCalledWith(1, 'BEGIN');
+    expect(db.query).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('INSERT INTO water_quality_logs'),
+      [
+        1,
+        'Morning',
+        expectedTimestamp,
+        7.1,
+        100,
+        200,
+        null,
+        1
+      ]
+    );
+    expect(db.query).toHaveBeenNthCalledWith(3, 'COMMIT');
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+});


### PR DESCRIPTION
## Summary
- stop sending `test_timestamp` from WaterTestLogManager and rely on server-generated timestamps
- document server-side timestamp handling for water log upserts
- add tests verifying upsert logs work without client-provided timestamps

## Testing
- `npm test`
- `(cd ice-order-ui && npm test)`

------
https://chatgpt.com/codex/tasks/task_e_689584827e24832895e29285c26b6cde