### PR TITLE
Hide scrollbars across browsers

### DIFF
--- a/ice-order-ui/src/index.css
+++ b/ice-order-ui/src/index.css
@@ -3,6 +3,18 @@
 @import url('https://fonts.googleapis.com/css2?family=Prompt:wght@300;400;500;600;700&display=swap');
 
 @theme {
-	--font-display: "Prompt", "sans-serif";
+        --font-display: "Prompt", "sans-serif";
+}
+
+html, body {
+  height: 100%;
+}
+body {
+  overflow: auto;
+  -ms-overflow-style: none;  /* IE and Edge */
+  scrollbar-width: none;     /* Firefox */
+}
+body::-webkit-scrollbar {
+  display: none;             /* Chrome, Safari, Opera */
 }
 


### PR DESCRIPTION
## Summary
- hide scrollbars while preserving scrolling with cross-browser CSS rules

## Testing
- `npm test`
- `cd ice-order-ui && npm test`
- `cd ice-order-ui && npm run lint` *(fails: 'global' is not defined, 'jest' is not defined, many others)*
- `cd ice-order-ui && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896bb8d5b8c8328bcc37fa968498840