### PR TITLE
feat: track expense paid date

### DIFF
--- a/db/migrations/202407021200_add_paid_date_to_expenses.sql
+++ b/db/migrations/202407021200_add_paid_date_to_expenses.sql
@@ -1,0 +1,2 @@
+ALTER TABLE expenses ADD COLUMN paid_date DATE;
+UPDATE expenses SET paid_date = expense_date WHERE paid_date IS NULL;

--- a/tests/expensesFileUpload.test.js
+++ b/tests/expensesFileUpload.test.js
@@ -85,6 +85,7 @@ describe('expense file upload', () => {
   test('PUT /api/expenses/:id updates expense with file', async () => {
     const oldRow = {
       expense_date: new Date('2024-02-01T00:00:00Z'),
+      paid_date: null,
       is_petty_cash_expense: false,
       related_document_url: 'old'
     };
@@ -92,6 +93,7 @@ describe('expense file upload', () => {
       expense_id: 3,
       is_petty_cash_expense: false,
       expense_date: '2024-02-01',
+      paid_date: '2024-02-01',
       related_document_url: 'http://fake.url/new.jpg'
     };
     mockClient.query
@@ -122,6 +124,7 @@ describe('expense file upload', () => {
       expect.stringContaining('UPDATE expenses'),
       [
         '2024-02-01',
+        '2024-02-01',
         1,
         'Upd',
         15,
@@ -138,6 +141,7 @@ describe('expense file upload', () => {
   test('DELETE /api/expenses/:id removes petty cash expense', async () => {
     const selectRow = {
       expense_date: new Date('2024-02-02T00:00:00Z'),
+      paid_date: null,
       is_petty_cash_expense: true
     };
     const deletedRow = { expense_id: 4 };


### PR DESCRIPTION
## Summary
- add migration for optional `paid_date` on expenses
- allow creating and updating expenses with `paid_date`
- use `paid_date` in date-based expense reports and petty cash totals

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68981845b1d883289c8ac26b30683cf3