### PR TITLE
Ensure expenses persist and filter paid date

### DIFF
--- a/ice-order-ui/src/__tests__/ExpenseList.test.jsx
+++ b/ice-order-ui/src/__tests__/ExpenseList.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 
 import ExpenseList from '../expenses/ExpenseList.jsx';
 
@@ -52,5 +52,69 @@ test('displays paid date when available', () => {
     />
   );
 
+  expect(screen.getByText('1 ม.ค. 2566')).toBeInTheDocument();
   expect(screen.getByText('2 ม.ค. 2566')).toBeInTheDocument();
+});
+
+test('sorts expenses by paid date then expense date', () => {
+  const expenses = [
+    {
+      expense_id: 1,
+      expense_date: '2023-01-01',
+      paid_date: '2023-01-10',
+      category_name: 'A',
+      description: 'Latest paid',
+      reference_details: '',
+      amount: 10,
+      is_petty_cash_expense: false,
+      payment_method: 'cash',
+      related_document_url: null
+    },
+    {
+      expense_id: 2,
+      expense_date: '2023-01-02',
+      paid_date: '2023-01-05',
+      category_name: 'B',
+      description: 'Earlier paid',
+      reference_details: '',
+      amount: 20,
+      is_petty_cash_expense: false,
+      payment_method: 'cash',
+      related_document_url: null
+    },
+    {
+      expense_id: 3,
+      expense_date: '2023-01-03',
+      paid_date: null,
+      category_name: 'C',
+      description: 'No paid date',
+      reference_details: '',
+      amount: 30,
+      is_petty_cash_expense: false,
+      payment_method: 'cash',
+      related_document_url: null
+    }
+  ];
+
+  render(
+    <ExpenseList
+      expenses={expenses}
+      onEdit={jest.fn()}
+      onDelete={jest.fn()}
+      isLoading={false}
+      pagination={{ page: 1, totalPages: 1, totalItems: 3 }}
+      onPageChange={jest.fn()}
+    />
+  );
+
+  const rows = screen.getAllByRole('row').slice(1); // skip header
+  const descriptions = rows.map((row) =>
+    within(row).getByText(/Latest paid|Earlier paid|No paid date/).textContent
+  );
+
+  expect(descriptions).toEqual([
+    'Latest paid',
+    'Earlier paid',
+    'No paid date'
+  ]);
 });

--- a/tests/expensesRoutesFilter.test.js
+++ b/tests/expensesRoutesFilter.test.js
@@ -1,0 +1,56 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../db/postgres', () => ({
+  query: jest.fn()
+}));
+
+jest.mock('../middleware/auth', () => ({
+  authMiddleware: (req, res, next) => { req.user = { id: 1 }; next(); },
+  requireRole: () => (req, res, next) => next()
+}));
+
+const expensesRoutes = require('../routes/expenses');
+const db = require('../db/postgres');
+
+describe('expenses filtering by paid_date', () => {
+  let app;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api/expenses', expensesRoutes);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('GET /api/expenses filters by paid_date range', async () => {
+    const expenseRow = {
+      expense_id: 1,
+      expense_date: '2024-01-01',
+      paid_date: '2024-01-02',
+      category_name: 'Meals',
+      description: 'Lunch',
+      amount: 10,
+      is_petty_cash_expense: false
+    };
+    db.query
+      .mockResolvedValueOnce({ rows: [expenseRow] })
+      .mockResolvedValueOnce({ rows: [{ count: '1' }] });
+
+    const res = await request(app).get(
+      '/api/expenses?paidStartDate=2024-01-02&paidEndDate=2024-01-02'
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(db.query).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('e.paid_date >= $1'),
+      ['2024-01-02', '2024-01-02', 20, 0]
+    );
+    expect(res.body.data).toEqual([expenseRow]);
+  });
+});
+


### PR DESCRIPTION
## Summary
- Include `paid_date` in expense upload tests and assert returned values
- Cover paid date rendering and sort order in `ExpenseList` frontend tests
- Add backend test for filtering expenses by `paid_date`

## Testing
- `npm test`
- `cd ice-order-ui && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68983d527fdc8328a484d8e3b7eb81e6